### PR TITLE
No code indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,10 @@ vectara:
   corpus_id: 4
   # the Vectara customer ID
   customer_id: 1234567
-  # flag: should vectara-ingest reindex if document already exists
+  # flag: should vectara-ingest reindex if document already exists (optional)
   reindex: false
+  # timeout (optional); sets the URL crawling timeout in seconds
+  timeout: 45
 
 crawling:
   # type of crawler; valid options are website, docusaurus, notion, jira, rss, mediawiki, discourse, github and others (this continues to evolve as new crawler types are added)

--- a/core/extract.py
+++ b/core/extract.py
@@ -1,8 +1,9 @@
 import logging
-from typing import Tuple, Optional
+from typing import Tuple
 
 from goose3 import Goose
 from goose3.text import StopWordsArabic, StopWordsKorean, StopWordsChinese
+from core.utils import remove_code
 
 import justext
 from bs4 import BeautifulSoup
@@ -109,7 +110,10 @@ def get_content_with_goose3(html_content: str, url: str, detected_language: str)
         logging.info(f"Error in Goose3 ({e}); that's okay Justext will fill in")
         return text, title
 
-def get_content_and_title(html_content: str, url: str, detected_language: str) -> Tuple[str, str]:
+def get_content_and_title(html_content: str, url: str, detected_language: str, include_code: bool = True) -> Tuple[str, str]:
+    if not include_code:
+        html_content = remove_code(html_content)
+
     text1, title1 = get_content_with_goose3(html_content, url, detected_language)
     text2, title2 = get_content_with_justext(html_content, detected_language)
     

--- a/core/extract.py
+++ b/core/extract.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 from goose3 import Goose
 from goose3.text import StopWordsArabic, StopWordsKorean, StopWordsChinese
-from core.utils import remove_code
+from core.utils import remove_code_from_html
 
 import justext
 from bs4 import BeautifulSoup
@@ -110,9 +110,9 @@ def get_content_with_goose3(html_content: str, url: str, detected_language: str)
         logging.info(f"Error in Goose3 ({e}); that's okay Justext will fill in")
         return text, title
 
-def get_content_and_title(html_content: str, url: str, detected_language: str, include_code: bool = True) -> Tuple[str, str]:
-    if not include_code:
-        html_content = remove_code(html_content)
+def get_content_and_title(html_content: str, url: str, detected_language: str, remove_code: bool = False) -> Tuple[str, str]:
+    if remove_code:
+        html_content = remove_code_from_html(html_content)
 
     text1, title1 = get_content_with_goose3(html_content, url, detected_language)
     text2, title2 = get_content_with_justext(html_content, detected_language)

--- a/core/indexer.py
+++ b/core/indexer.py
@@ -31,13 +31,14 @@ class Indexer(object):
         corpus_id (int): ID of the Vectara corpus to index to.
         api_key (str): API key for the Vectara API.
     """
-    def __init__(self, cfg: OmegaConf, endpoint: str, customer_id: str, corpus_id: int, api_key: str, reindex: bool = True) -> None:
+    def __init__(self, cfg: OmegaConf, endpoint: str, customer_id: str, corpus_id: int, api_key: str, reindex: bool = True, index_code: bool = False) -> None:
         self.cfg = cfg
         self.endpoint = endpoint
         self.customer_id = customer_id
         self.corpus_id = corpus_id
         self.api_key = api_key
         self.reindex = reindex
+        self.index_code = index_code
         self.timeout = 30
         self.detected_language: Optional[str] = None
 
@@ -267,7 +268,7 @@ class Indexer(object):
                 exporter = HTMLExporter()
                 html_content, _ = exporter.from_notebook_node(nb)
             extracted_title = url.split('/')[-1]      # no title in these files, so using file name
-            text = html_to_text(html_content)
+            text = html_to_text(html_content, self.index_code)
             parts = [text]
 
         # for everything else, use PlayWright as we may want it to render JS on the page before reading the content
@@ -282,7 +283,7 @@ class Indexer(object):
                     self.detected_language = detect_language(body_text)
                     logging.info(f"The detected language is {self.detected_language}")
                 url = actual_url
-                text, extracted_title = get_content_and_title(html_content, url, self.detected_language)
+                text, extracted_title = get_content_and_title(html_content, url, self.detected_language, self.index_code)
                 parts = [text]
                 logging.info(f"retrieving content took {time.time()-st:.2f} seconds")
             except Exception as e:

--- a/core/indexer.py
+++ b/core/indexer.py
@@ -31,15 +31,15 @@ class Indexer(object):
         corpus_id (int): ID of the Vectara corpus to index to.
         api_key (str): API key for the Vectara API.
     """
-    def __init__(self, cfg: OmegaConf, endpoint: str, customer_id: str, corpus_id: int, api_key: str, reindex: bool = True, index_code: bool = False) -> None:
+    def __init__(self, cfg: OmegaConf, endpoint: str, customer_id: str, corpus_id: int, api_key: str, reindex: bool = True, remove_code: bool = True) -> None:
         self.cfg = cfg
         self.endpoint = endpoint
         self.customer_id = customer_id
         self.corpus_id = corpus_id
         self.api_key = api_key
         self.reindex = reindex
-        self.index_code = index_code
-        self.timeout = 45
+        self.remove_code = remove_code
+        self.timeout = cfg.vectara.get("timeout", 30)
         self.detected_language: Optional[str] = None
 
         self.setup()
@@ -268,7 +268,7 @@ class Indexer(object):
                 exporter = HTMLExporter()
                 html_content, _ = exporter.from_notebook_node(nb)
             extracted_title = url.split('/')[-1]      # no title in these files, so using file name
-            text = html_to_text(html_content, self.index_code)
+            text = html_to_text(html_content, self.remove_code)
             parts = [text]
 
         # for everything else, use PlayWright as we may want it to render JS on the page before reading the content
@@ -283,7 +283,7 @@ class Indexer(object):
                     self.detected_language = detect_language(body_text)
                     logging.info(f"The detected language is {self.detected_language}")
                 url = actual_url
-                text, extracted_title = get_content_and_title(html_content, url, self.detected_language, self.index_code)
+                text, extracted_title = get_content_and_title(html_content, url, self.detected_language, self.remove_code)
                 parts = [text]
                 logging.info(f"retrieving content took {time.time()-st:.2f} seconds")
             except Exception as e:

--- a/core/indexer.py
+++ b/core/indexer.py
@@ -39,7 +39,7 @@ class Indexer(object):
         self.api_key = api_key
         self.reindex = reindex
         self.index_code = index_code
-        self.timeout = 30
+        self.timeout = 45
         self.detected_language: Optional[str] = None
 
         self.setup()
@@ -50,7 +50,7 @@ class Indexer(object):
         self.p = sync_playwright().start()
         self.browser = self.p.firefox.launch(headless=True)
 
-    def fetch_content_with_timeout(self, url: str, timeout: int = 30) -> Tuple[str, str] :
+    def fetch_content_with_timeout(self, url: str) -> Tuple[str, str] :
         '''
         Fetch content from a URL with a timeout.
         Args:
@@ -67,7 +67,7 @@ class Indexer(object):
                 if route.request.resource_type == "image" 
                 else route.continue_() 
             ) 
-            page.goto(url, timeout=timeout*1000)
+            page.goto(url, timeout=self.timeout*1000)
             content = page.content()
             out_url = page.url
         except PlaywrightTimeoutError:

--- a/core/utils.py
+++ b/core/utils.py
@@ -11,15 +11,15 @@ doc_extensions = ["doc", "docx", "ppt", "pptx", "xls", "xlsx", "pdf", "ps"]
 archive_extensions = ["zip", "gz", "tar", "bz2", "7z", "rar"]
 binary_extensions = archive_extensions + img_extensions + doc_extensions
 
-def remove_code(html_text: str) -> str:
+def remove_code_from_html(html_text: str) -> str:
     soup = BeautifulSoup(html_text, 'html.parser')
-    for tag in soup.find_all(['code', 'pre', 'script']):
+    for tag in soup.find_all(['code', 'script']):
         tag.decompose()
     return str(soup)
 
 def html_to_text(html: str, include_code: bool = True) -> str:
     if not include_code:
-        html = remove_code(html)
+        html = remove_code_from_html(html)
     soup = BeautifulSoup(html, features='html.parser')
     return soup.get_text()
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -11,7 +11,15 @@ doc_extensions = ["doc", "docx", "ppt", "pptx", "xls", "xlsx", "pdf", "ps"]
 archive_extensions = ["zip", "gz", "tar", "bz2", "7z", "rar"]
 binary_extensions = archive_extensions + img_extensions + doc_extensions
 
-def html_to_text(html: str) -> str:
+def remove_code(html_text: str) -> str:
+    soup = BeautifulSoup(html_text, 'html.parser')
+    for tag in soup.find_all(['code', 'pre', 'script']):
+        tag.decompose()
+    return str(soup)
+
+def html_to_text(html: str, include_code: bool = True) -> str:
+    if not include_code:
+        html = remove_code(html)
     soup = BeautifulSoup(html, features='html.parser')
     return soup.get_text()
 

--- a/crawlers/CRAWLERS.md
+++ b/crawlers/CRAWLERS.md
@@ -134,7 +134,7 @@ It has two parameters
 - `neg_regex` defines one or more (optional) regex expressions defining URLs to match for exclusion
 - `extensions_to_ignore` specifies one or more file extensions that we want to ignore and not index into Vectara.
 - `doc_system` defines the type of documentation system we will crawl for content. Currently supported `docusaurus` or `readthedocs`
-- `include_code` if true (default) then include code segments in what is indexed, otherwise ignore those sections (`<script>, <pre> and <code>`)
+- `remove_code` if true (default) then removes all code segments (with tags `<script> and <code>`) in what is indexed, otherwise keeps those sections 
 - `ray_workers` if it exists defines the number of ray workers to use for parallel processing. ray_workers=0 means dont use Ray. ray_workers=-1 means use all cores available.
 Note that ray with docker does not work on Mac M1/M2 machines.
 

--- a/crawlers/CRAWLERS.md
+++ b/crawlers/CRAWLERS.md
@@ -130,9 +130,11 @@ The RSS crawler can be used to crawl URLs listed in RSS feeds such as on news si
 The Docs crawler processes and indexes content published on different documentation systems.
 It has two parameters
 - `base_urls` defines one or more base URLS for the documentation content.
-- `url_regex` defines one or more (optional) regex expressions to include in the content crawl.
+- `pos_regex` defines one or more (optional) regex expressions defining URLs to match for inclusion
+- `neg_regex` defines one or more (optional) regex expressions defining URLs to match for exclusion
 - `extensions_to_ignore` specifies one or more file extensions that we want to ignore and not index into Vectara.
 - `doc_system` defines the type of documentation system we will crawl for content. Currently supported `docusaurus` or `readthedocs`
+- `include_code` if true (default) then include code segments in what is indexed, otherwise ignore those sections (`<script>, <pre> and <code>`)
 - `ray_workers` if it exists defines the number of ray workers to use for parallel processing. ray_workers=0 means dont use Ray. ray_workers=-1 means use all cores available.
 Note that ray with docker does not work on Mac M1/M2 machines.
 

--- a/crawlers/docs_crawler.py
+++ b/crawlers/docs_crawler.py
@@ -119,7 +119,7 @@ class DocsCrawler(Crawler):
         self.extensions_to_ignore = list(set(self.cfg.docs_crawler.extensions_to_ignore + binary_extensions))
         self.pos_regex = [re.compile(r) for r in self.cfg.docs_crawler.get("pos_regex", [])]
         self.neg_regex = [re.compile(r) for r in self.cfg.docs_crawler.get("neg_regex", [])]
-        self.indexer.index_code = self.cfg.docs_crawler.get("include_code", True)
+        self.indexer.remove_code = self.cfg.docs_crawler.get("remove_code", True)
 
         self.session = create_session_with_retries()
         self.rate_limiter = RateLimiter(max_calls=2, period=1)

--- a/crawlers/docs_crawler.py
+++ b/crawlers/docs_crawler.py
@@ -119,6 +119,7 @@ class DocsCrawler(Crawler):
         self.extensions_to_ignore = list(set(self.cfg.docs_crawler.extensions_to_ignore + binary_extensions))
         self.pos_regex = [re.compile(r) for r in self.cfg.docs_crawler.get("pos_regex", [])]
         self.neg_regex = [re.compile(r) for r in self.cfg.docs_crawler.get("neg_regex", [])]
+        self.indexer.index_code = self.cfg.docs_crawler.get("include_code", True)
 
         self.session = create_session_with_retries()
         self.rate_limiter = RateLimiter(max_calls=2, period=1)


### PR DESCRIPTION
Added ability in docs_crawler to remove code segments from HTML content before sending to Vectara
IF enabled, it removes any text associated with <code> or <script> tags