### PR TITLE
fix(vectara-ingest): added the code to get the api endpoint from the config

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -120,7 +120,7 @@ def main() -> None:
         # default (otherwise) - add to vectara config
         OmegaConf.update(cfg['vectara'], k, v)
 
-    endpoint = 'api.vectara.io'
+    endpoint = cfg.vectara.endpoint if cfg.vectara.endpoint is not None else 'api.vectara.io'
     customer_id = cfg.vectara.customer_id
     corpus_id = cfg.vectara.corpus_id
     api_key = cfg.vectara.api_key


### PR DESCRIPTION
Currently, the api endpoint is hardcoded to api.vectara.io. Changed the code to use the endpoint form the config, if present, else use the hardcoded default value.