### PR TITLE
updated hackernews crawler

### DIFF
--- a/config/hackernews.yaml
+++ b/config/hackernews.yaml
@@ -8,3 +8,5 @@ crawling:
 
 hackernews_crawler:
   max_articles: 1000
+  days_back: 3
+  days_back_comprehensive: false

--- a/config/sf.yaml
+++ b/config/sf.yaml
@@ -11,5 +11,6 @@ website_crawler:
   delay: 1
   pos_regex: [".*sf.gov.*"]
   neg_regex: [".*sf.gov/es/.*", ".*sf.gov/fil/.*", ".*sf.gov/zh-hant/.*"]
-  pages_source: sitemap # options are: (1) 'sitemap' automatically retreived from website (2) 'crawl' for recursive crawling
+  pages_source: crawl # options are: (1) 'sitemap' automatically retreived from website (2) 'crawl' for recursive crawling
+  max_depth: 3
   extraction: playwright # pdf or playwright

--- a/crawlers/CRAWLERS.md
+++ b/crawlers/CRAWLERS.md
@@ -136,6 +136,21 @@ The RSS crawler can be used to crawl URLs listed in RSS feeds such as on news si
 - `delay` defines the number of seconds between to wait between news articles, so as to make the crawl more friendly to the hosting site.
 - `extraction` defines how we process URLs (pdf or html) as as with the website crawler.
 
+### Hackernews crawler
+
+```yaml
+...
+hackernews_crawler:
+  max_articles: 1000
+  days_past: 3
+  days_past_comprehensive: false
+```
+
+The hackernews crawler can be used to crawl stories and comments from hacker news.
+- `max_articles` specifies a limit to the number of stories crawled. 
+- `days_past` specifies the number of days backward to crawl, based on the top, new, ask, show and best story lists. For example with a value of 3 as in this example, the crawler will only index stories if the story or any comment in the story was published or updated in the last 3 days.
+- `days_past_comprehensive` if true, then the crawler performs a comprehensive search for ALL stories published within the last `days_past` days (which takes longer to run)
+
 ### Docs crawler
 
 ```yaml
@@ -265,6 +280,5 @@ The S3 crawler indexes all content that's in a specified S3 bucket path.
 
 - `Edgar` crawler: crawls SEC Edgar annual reports (10-K) and indexes those into Vectara
 - `fmp` crawler: crawls information about public companies using the [FMP](https://site.financialmodelingprep.com/developer/docs/) API
-- `Hacker News` crawler: crawls the best, most recent an most popular Hacker News stories
 - `PMC` crawler: crawls medical articles from PubMed Central and indexes them into Vectara.
 - `Arxiv` crawler: crawls the top (most cited or latest) Arxiv articles about a topic and indexes them into Vectara.

--- a/crawlers/hackernews_crawler.py
+++ b/crawlers/hackernews_crawler.py
@@ -93,7 +93,7 @@ class HackernewsCrawler(Crawler):
 
     def crawl(self) -> None:
         # Retrieve the IDs of the top N_ARTICLES stories
-        resp1= self.session.get(self.db_url + 'topstories.json')
+        resp1 = self.session.get(self.db_url + 'topstories.json')
         resp2 = self.session.get(self.db_url + 'newstories.json')
         resp3 = self.session.get(self.db_url + 'beststories.json')
         resp4 = self.session.get(self.db_url + 'showstories.json')

--- a/crawlers/hackernews_crawler.py
+++ b/crawlers/hackernews_crawler.py
@@ -1,44 +1,68 @@
 
-import requests
+import json
+from omegaconf import OmegaConf
 import logging
 from core.crawler import Crawler
-import os
 from core.utils import html_to_text, create_session_with_retries
-from slugify import slugify
-
+import datetime
 from typing import List
-
-def get_comments(kids: List[str], entrypoint: str) -> List[str]:
-    comments = []
-    for kid in kids:
-        try:
-            response = requests.get(entrypoint + 'item/{}.json'.format(kid))
-            comment = response.json()
-        except Exception as e:
-            logging.info(f"Error retrieving comment {kid}, e={e}")
-            comment = None
-        if comment is not None and comment.get('type', '') == 'comment':
-            comments.append(html_to_text(comment.get('text', '')))
-            sub_kids = comment.get('kids', [])
-            if len(sub_kids)>0:
-                comments += get_comments(sub_kids, entrypoint)
-    return comments
 
 class HackernewsCrawler(Crawler):
 
+    def __init__(self, cfg: OmegaConf, endpoint: str, customer_id: str, corpus_id: int, api_key: str) -> None:
+        super().__init__(cfg, endpoint, customer_id, corpus_id, api_key)
+        self.N_ARTICLES = self.cfg.hackernews_crawler.max_articles
+        self.days_back = self.cfg.hackernews_crawler.get("days_back", 3)
+        self.indexer.reindex = True     # always reindex with hackernews, since it depends on comments
+        self.db_url = 'https://hacker-news.firebaseio.com/v0/'
+        self.session = create_session_with_retries()
+
+    def get_comments(self, story: dict) -> List[str]:
+        comments = []
+        kids = [str(k) for k in story.get('kids', [])]
+        for kid in kids:
+            try:
+                response = self.session.get(self.db_url + 'item/{}.json'.format(kid))
+                comment = response.json()
+            except Exception as e:
+                logging.info(f"Error retrieving comment {kid}, e={e}")
+                comment = None
+            if comment is not None and comment.get('type', '') == 'comment':
+                comments.append(comment)
+                comments += self.get_comments(comment)
+        return comments
+
+    def index_story(self, id: str) -> None:
+        url = f'https://news.ycombinator.com/item?id={id}'
+        story = self.session.get(self.db_url + 'item/{}.json'.format(id)).json()
+        doc_id = str(story['id'])
+        doc_title = html_to_text(story.get('title', ''))
+        doc_text = html_to_text(story.get('text', ''))
+        doc_metadata = {'source': 'hackernews', 'title': doc_title, 'url': url}
+        texts = [] if len(doc_text) == 0 else [doc_text]
+        titles = ['']
+        times = [datetime.datetime.fromtimestamp(story.get('time', 0)).date()]
+        comments = self.get_comments(story)
+        for comment in comments:
+            texts.append(html_to_text(comment.get('text', '')))
+            titles.append(html_to_text(comment.get('title', '')))
+            times.append(datetime.datetime.fromtimestamp(comment.get('time', 0)).date())
+        
+        # if most recent comment is older than days_back, don't index
+        if max(times) < datetime.datetime.now().date() - datetime.timedelta(days=self.days_back):
+            logging.info(f"Skipping story {id} because most recent comment is older than {self.days_back} days")
+            return
+            
+        self.indexer.index_segments(doc_id=doc_id, 
+                                    texts=texts, titles=titles, metadatas=None,
+                                    doc_metadata=doc_metadata, doc_title=doc_title)
+
     def crawl(self) -> None:
-        N_ARTICLES = self.cfg.hackernews_crawler.max_articles
-
-        # URL for the Hacker News API
-        entrypoint = 'https://hacker-news.firebaseio.com/v0/'
-
         # Retrieve the IDs of the top N_ARTICLES stories
-        session = create_session_with_retries()
-        resp1= session.get(entrypoint + 'topstories.json')
-        resp2 = session.get(entrypoint + 'newstories.json')
-        resp3 = session.get(entrypoint + 'beststories.json')
-
-        top_ids = list(set(list(resp1.json()) + list(resp2.json()) + list(resp3.json())))[:N_ARTICLES]
+        resp1= self.session.get(self.db_url + 'topstories.json')
+        resp2 = self.session.get(self.db_url + 'newstories.json')
+        resp3 = self.session.get(self.db_url + 'beststories.json')
+        top_ids = list(set(list(resp1.json()) + list(resp2.json()) + list(resp3.json())))[:self.N_ARTICLES]
         num_ids = len(top_ids)
         logging.info(f"Crawling {num_ids} stories")
 
@@ -47,22 +71,7 @@ class HackernewsCrawler(Crawler):
             if n_id % 20 == 0:
                 logging.info(f"Crawled {n_id} stories so far")
             try:
-                response = session.get(entrypoint + 'item/{}.json'.format(id))
-                story = response.json()
-                url = story.get('url', None)
-                if url is None:
-                    continue
-                title = html_to_text(story.get('title', ''))
-                text = story.get('text', None)
-                if text:
-                    fname = slugify(url) + ".html"
-                    with open(fname, 'w') as f:
-                        f.write(text)
-                    self.indexer.index_file(fname, uri=url, metadata={'title': title, 'url': url})
-                    os.remove(fname)
-                else:
-                    metadata = {'source': 'hackernews', 'title': title, 'url': url}
-                    self.indexer.index_url(url, metadata=metadata)
+                self.index_story(str(id))
             except Exception as e:
                 import traceback
-                logging.error(f"Error crawling story {url}, error={e}, traceback={traceback.format_exc()}")
+                logging.error(f"Error crawling story {id}, error={e}, traceback={traceback.format_exc()}")

--- a/crawlers/hackernews_crawler.py
+++ b/crawlers/hackernews_crawler.py
@@ -71,14 +71,15 @@ class HackernewsCrawler(Crawler):
         stories_ids = []
         
         # Iterate backwards from the current highest ID
-        for item_id in range(max_item_id, 0, -1):
+        for inx, item_id in enumerate(range(max_item_id, 0, -1)):
             item_response = self.session.get(f"https://hacker-news.firebaseio.com/v0/item/{item_id}.json")
             item = item_response.json()
+            item_date = datetime.datetime.fromtimestamp(item.get("time"))
+            if inx % 100 == 0:
+                logging.info(f"Checked {inx} items so far, lates item with date {item_date}")
 
             # Check if item is a story and was published within the desired time frame
             if item and item.get("type") == "story":
-                item_date = datetime.datetime.fromtimestamp(item.get("time"))
-                logging.info(f"Checking item {item_id}, with date {item_date}")
                 if item_date >= cutoff_date:
                     stories_ids.append(item_id)
                 else:

--- a/crawlers/hackernews_crawler.py
+++ b/crawlers/hackernews_crawler.py
@@ -54,6 +54,10 @@ class HackernewsCrawler(Crawler):
             logging.info(f"Skipping story {id} because most recent comment is older than {self.days_back} days")
             return
             
+        if len(texts) == 0:
+            logging.info(f"Skipping story {id} because it has no text")
+            return
+        
         self.indexer.index_segments(doc_id=doc_id, 
                                     texts=texts, titles=titles, metadatas=None,
                                     doc_metadata=doc_metadata, doc_title=doc_title)


### PR DESCRIPTION
- Not crawling the external URLs, just the stories and comments
- Supports days_back parameters
- Only reindexes documents if the story or comment has been updated within the days_back range