### PR TITLE
Option to remove docs not crawled

### DIFF
--- a/crawlers/CRAWLERS.md
+++ b/crawlers/CRAWLERS.md
@@ -28,6 +28,7 @@ website_crawler:
     extraction: playwright
     keep_query_params: false
     crawl_report: false
+    remove_old_content: false
     ray_workers: 0
 ...
 ```
@@ -45,7 +46,9 @@ Other parameters:
 - `pos_regex` defines one or more (optional) regex expressions defining URLs to match for inclusion.
 - `neg_regex` defines one or more (optional) regex expressions defining URLs to match for exclusion.
 - `keep_query_params`: if true, maintains the full URL including query params in the URL. If false, then it removes query params from collected URLs.
-- `crawl_report`: if true, creates a file under ~/tmp/mount called "crawl_report.txt" that lists all URLs crawled
+- `crawl_report`: if true, creates a file under ~/tmp/mount called `urls_indexed.txt` that lists all URLs crawled
+- `remove_old_content`: if true, removed any URL that currently exists in the corpus but is NOT in this crawl. CAUTION: this removed data from your corpus. 
+If `crawl_report` is true then the list of URLs associated with the removed documents is listed in `urls_removed.txt`
  
 <br>**Note**: when specifying regular expressions it's recommended to use single quotes (as opposed to double quotes) to avoid issues with escape characters.
 
@@ -172,6 +175,7 @@ The hackernews crawler can be used to crawl stories and comments from hacker new
     docs_system: docusaurus
     remove_code: true
     crawl_report: false
+    remove_old_content: false
     ray_workers: 0
 ```
 
@@ -184,7 +188,9 @@ It has two parameters
 - `doc_system` is a text string specifying the document system crawled, and is added to the metadata under "source"
 - `ray_workers` if it exists defines the number of ray workers to use for parallel processing. ray_workers=0 means dont use Ray. ray_workers=-1 means use all cores available.
 - `num_per_second` specifies the number of call per second when crawling the website, to allow rate-limiting. Defaults to 10.
-- `crawl_report`: if true, creates a file under ~/tmp/mount called "crawl_report.txt" that lists all URLs crawled
+- `crawl_report`: if true, creates a file under ~/tmp/mount called `urls_indexed.txt` that lists all URLs crawled
+- `remove_old_content`: if true, removed any URL that currently exists in the corpus but is NOT in this crawl. CAUTION: this removed data from your corpus. 
+If `crawl_report` is true then the list of URLs associated with the removed documents is listed in `urls_removed.txt`
 
 <br>**Note**: when specifying regular expressions it's recommended to use single quotes (as opposed to double quotes) to avoid issues with escape characters.
 

--- a/crawlers/docs_crawler.py
+++ b/crawlers/docs_crawler.py
@@ -134,10 +134,25 @@ class DocsCrawler(Crawler):
 
         logging.info(f"Found {len(self.crawled_urls)} urls in {self.cfg.docs_crawler.base_urls}")
         if self.cfg.docs_crawler.get("crawl_report", False):
-            with open('/home/vectara/env/crawl_report.txt', 'w') as f:
+            logging.info(f"Collected {len(self.crawled_urls)} URLs to crawl and index. See urls_indexed.txt for a full report.")
+            with open('/home/vectara/env/urls_indexed.txt', 'w') as f:
                 for url in sorted(self.crawled_urls):
                     f.write(url + '\n')
+        else:
+            logging.info(f"Collected {len(self.crawled_urls)} URLs to crawl and index.")
 
+        # Determine which URLs to remove from corpus
+        if self.cfg.docs_crawler.get("remove_old_content", False):
+            existing_docs = self.indexer._list_docs()
+            docs_to_remove = [t for t in existing_docs if t['url'] and t['url'] not in self.crawled_urls]
+            for doc in docs_to_remove:
+                if doc['url']:
+                    self.indexer.delete_doc(doc['doc_id'])
+            logging.info(f"Removing {len(docs_to_remove)} that are not included in the crawl but are in the corpus.")
+            if self.cfg.docs_crawler.get("crawl_report", False):
+                with open('/home/vectara/env/urls_removed.txt', 'w') as f:
+                    for url in sorted([t['url'] for t in docs_to_remove if t['url']]):
+                        f.write(url + '\n')
 
         if ray_workers == -1:
             ray_workers = psutil.cpu_count(logical=True)


### PR DESCRIPTION
Added remove_old_content configuration option.
If enabled, if will use the list-documents API to list all documents in the corpus crawled, and then compare that against the list of documents crawled in this session, while removing any previously indexed documents that are no longer there. THis helps when re-crawling of the entire corpus occurs periodically where some pages may be deprecated by the source (e.g. in website or docs crawling)