### PR TITLE
Update FMP/Edgar crawler

### DIFF
--- a/core/indexer.py
+++ b/core/indexer.py
@@ -58,7 +58,7 @@ def parse_local_file(filename: str, uri: str, summarize_tables: bool = False, op
                                         strategy='hi_res', hi_res_model_name='yolox')  # use 'detectron2_onnx' for a faster model
         else:
             elements = partition_pdf(filename, strategy='fast')
-    elif mime_type == 'text/html':
+    elif mime_type == 'text/html' or mime_type == 'application/xml':
         elements = partition_html(filename=filename)
     elif mime_type == 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
         elements = partition_docx(filename=filename)

--- a/crawlers/edgar_crawler.py
+++ b/crawlers/edgar_crawler.py
@@ -17,13 +17,15 @@ from typing import Dict, List
 
 from dataclasses import asdict
 
+company = "MyCompany"
+email = "me@mycompany.com"
     
 def get_headers() -> Dict[str, str]:
     """
     Get a set of headers to use for HTTP requests.
     """
     headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:98.0) Gecko/20100101 Firefox/98.0",
+        "User-Agent": f"{company} {email}",
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8" 
     }
     return headers
@@ -32,7 +34,7 @@ def get_headers() -> Dict[str, str]:
 def get_filings(ticker: str, start_date_str: str, end_date_str: str, filing_type: str = "10-K") -> List[Dict[str, str]]:
     folder = 'edgar_dl'
     ensure_empty_folder(folder)
-    dl = Downloader("MyCompany", "me@mycompany.com")
+    dl = Downloader(f"{company} {email}")
 
     start_date = datetime.strptime(start_date_str, '%Y-%m-%d')
     end_date = datetime.strptime(end_date_str, '%Y-%m-%d')    

--- a/crawlers/fmp_crawler.py
+++ b/crawlers/fmp_crawler.py
@@ -61,7 +61,10 @@ class FmpCrawler(Crawler):
                 doc_title = f"10-K for {company_name} from {year}"
                 rel_filings = [f for f in filings if f['acceptedDate'][:4] == str(year)]
                 url = rel_filings[0]['finalLink'] if len(rel_filings)>0 else None
-                metadata = {'source': ticker.lower(), 'title': doc_title, 'ticker': ticker, 'company name': company_name, 'year': year, 'type': '10-K', 'url': url}
+                metadata = {
+                    'source': ticker.lower(), 'title': doc_title, 'ticker': ticker, 'company name': company_name, 'year': year, 
+                    'type': 'filing', 'filing_type': '10-K', 'url': url
+                }
                 document: Dict[str, Any] = {
                     "documentId": f"10-K-{company_name}-{year}",
                     "title": doc_title,
@@ -100,7 +103,10 @@ class FmpCrawler(Crawler):
                 if response.status_code == 200:
                     for transcript in response.json():
                         title = f"Earnings call transcript for {company_name}, quarter {quarter} of {year}"
-                        metadata = {'source': ticker.lower(), 'title': title, 'ticker': ticker, 'company name': company_name, 'year': year, 'quarter': quarter, 'type': 'transcript'}
+                        metadata = {
+                            'source': ticker.lower(), 'title': title, 'ticker': ticker, 'company name': company_name, 
+                            'year': year, 'quarter': quarter, 'type': 'transcript'
+                        }
                         document = {
                             "documentId": f"transcript-{company_name}-{year}-{quarter}",
                             "title": title,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.32.2
 certifi>=2024.2.2
 pdfkit==1.0.0
-authlib==1.2.0
+authlib==1.3.1
 feedparser==6.0.10
 pyyaml>=6.0
 beautifulsoup4==4.12.3


### PR DESCRIPTION
Added company/email to header (edgar crawler)
FMP crawler metadata - updated to have 'type' and if crawling a filing then also 'filing_type'
indexer to support other types of HTML files for local processing of files with tables.
