### PR TITLE
Support for reading secrets.toml path from environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dmypy.json
 project.yaml
 
 .idea/
+config-private

--- a/ingest.py
+++ b/ingest.py
@@ -163,9 +163,10 @@ def main() -> None:
         logging.error(f"Error loading config file ({config_name}): {e}")
         return
 
+    secrets_path = os.environ.get('VECTARA_SECRETS_PATH', '/home/vectara/env/secrets.toml')
     # add .env params, by profile
-    volume = '/home/vectara/env'
-    with open(f"{volume}/secrets.toml", "r") as f:
+    logging.info(f"Loading {secrets_path}")
+    with open(secrets_path, "r") as f:
         env_dict = toml.load(f)
     if profile_name not in env_dict:
         logging.info(f'Profile "{profile_name}" not found in secrets.toml')


### PR DESCRIPTION
- **Website crawler upd2 (#146)**
- **updated README to reflect llama_parse (#147)**
- **Hotfix 2 (#148)**
- **bugfix (#149)**
- **update docling version for bugfix (#150)**
- **Confluence support. (#144)**
- **Website crawler update (#151)**
- **Added support to read the location of secrets.toml from an environment variable `VECTARA_SECRETS_PATH`. Defaults to the original path. Fixes #160.**
