### PR TITLE
External SSL Certificate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,10 @@ vectara:
   # Which whisper model to use for audio files (relevant for YT, S3 and folder crawlers)
   # Valid values: tiny, base, small, medium or large. Defaults to base.
   whisper_model: the model name for whisper
-
+  # Whether the session should trust the environment settings. When set to 
+  ssl_trust_env: None
+  # Path to the CA certificate file for SSL verification.
+  ssl_ca_cert: None 
 
 doc_processing:
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ vectara:
   # Which whisper model to use for audio files (relevant for YT, S3 and folder crawlers)
   # Valid values: tiny, base, small, medium or large. Defaults to base.
   whisper_model: the model name for whisper
-  # Whether the session should trust the environment settings. When set to 
+  # Whether the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
   ssl_trust_env: None
   # Path to the CA certificate file for SSL verification.
   ssl_ca_cert: None 

--- a/README.md
+++ b/README.md
@@ -205,9 +205,11 @@ vectara:
   # Valid values: tiny, base, small, medium or large. Defaults to base.
   whisper_model: the model name for whisper
   # Whether the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
-  ssl_trust_env: None
-  # Path to the CA certificate file for SSL verification.
-  ssl_ca_cert: None 
+  ssl_verify: None  
+  # If `False`, SSL verification is disabled (not recommended for production). 
+  # If a string, it is treated as the path to a custom CA certificate file. 
+  # If `True` or not provided, default SSL verification is used.
+
 
 doc_processing:
 

--- a/core/indexer.py
+++ b/core/indexer.py
@@ -31,7 +31,7 @@ from core.summary import TableSummarizer, ImageSummarizer, get_attributes_from_t
 from core.utils import (
     html_to_text, detect_language, get_file_size_in_MB, create_session_with_retries,
     mask_pii, safe_remove_file, url_to_filename, df_cols_to_headers, html_table_to_header_and_rows,
-    get_file_path_from_url, create_row_items
+    get_file_path_from_url, create_row_items, configure_session_for_ssl
 )
 from core.extract import get_article_content
 from core.doc_parser import UnstructuredDocumentParser, DoclingDocumentParser, LlamaParseDocumentParser
@@ -229,6 +229,8 @@ class Indexer:
 
     def setup(self, use_playwright: bool = True) -> None:
         self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, self.cfg.vectara)
+
         # Create playwright browser so we can reuse it across all Indexer operations
         if use_playwright:
             self.p = sync_playwright().start()

--- a/core/utils.py
+++ b/core/utils.py
@@ -196,8 +196,8 @@ def configure_session_for_ssl(session: requests.Session, config: DictConfig) -> 
     ```
     """
     trust_env = config.get("ssl_trust_env", None)
-    if trust_env:
-        session.trust_env = trust_env
+    if trust_env is False:
+        session.trust_env = False
     ca_cert = config.get("ssl_ca_cert", None)
     if ca_cert:
         session.cert = ca_cert

--- a/core/utils.py
+++ b/core/utils.py
@@ -170,7 +170,7 @@ def configure_session_for_ssl(session: requests.Session, config: DictConfig) -> 
 
     config : DictConfig
         A dictionary containing SSL-related configurations.
-        - "ssl_trust_env" (bool, optional): Whether the session should trust the environment settings.
+        - "ssl_ignore_cert_errors" (bool, optional): Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
         - "ssl_ca_cert" (str, optional): Path to the CA certificate file for SSL verification.
 
     Returns:
@@ -185,7 +185,7 @@ def configure_session_for_ssl(session: requests.Session, config: DictConfig) -> 
 
     session = requests.Session()
     config = {
-        "ssl_trust_env": True,
+        "ssl_ignore_cert_errors": True,
         "ssl_ca_cert": "/path/to/custom_ca.crt"
     }
 
@@ -195,8 +195,8 @@ def configure_session_for_ssl(session: requests.Session, config: DictConfig) -> 
     print(response.status_code)
     ```
     """
-    trust_env = config.get("ssl_trust_env", None)
-    if trust_env is False:
+    ssl_ignore_cert_errors = config.get("ssl_ignore_cert_errors", False)
+    if ssl_ignore_cert_errors:
         session.trust_env = False
     ca_cert = config.get("ssl_ca_cert", None)
     if ca_cert:

--- a/core/utils.py
+++ b/core/utils.py
@@ -177,12 +177,24 @@ def configure_session_for_ssl(session: requests.Session, config: DictConfig) -> 
     """
     ssl_verify = config.get("ssl_verify", None)
 
-    if ssl_verify is False:
-        logging.warning("Disabling ssl verification for session.")
-        session.verify = False
-    elif ssl_verify:
-        logging.info(f"Setting session.verify to {ssl_verify}")
-        session.verify = ssl_verify
+    if isinstance(ssl_verify, bool):
+        if not ssl_verify:
+            logging.warning("Disabling ssl verification for session.")
+            session.verify = False
+        else:
+            logging.debug("SSL verify using default behavior")
+    elif isinstance(ssl_verify, str):
+        if "false" == ssl_verify.lower() or "0" == ssl_verify:
+            logging.warning("Disabling ssl verification for session.")
+            session.verify = False
+        elif "true" == ssl_verify.lower() or "1" == ssl_verify:
+            logging.debug("SSL verify using default behavior")
+        else:
+            logging.info(f"Configuring session.verify to {ssl_verify}")
+            if not os.path.exists(ssl_verify):
+                raise FileNotFoundError(f"CA file ('{ssl_verify}') could not be found.")
+            session.verify = ssl_verify
+
 
 def remove_anchor(url: str) -> str:
     """Remove the anchor from a URL."""

--- a/core/utils.py
+++ b/core/utils.py
@@ -157,50 +157,32 @@ def create_session_with_retries(retries: int = 5) -> requests.Session:
 
 def configure_session_for_ssl(session: requests.Session, config: DictConfig) -> None:
     """
-    Configures an existing requests session with SSL settings.
+    Configure SSL settings for a requests session.
 
-    This function applies SSL-related configurations to the provided `requests.Session`
-    object based on the `config` dictionary. It can set whether the session should
-    trust environment settings and specify a custom CA certificate for SSL verification.
+    This function updates the SSL verification settings of the provided `requests.Session`
+    based on the configuration provided. It allows disabling SSL verification for
+    debugging purposes or specifying a custom CA certificate.
 
     Parameters:
     -----------
     session : requests.Session
-        The requests session to configure.
+        The requests session to configure with SSL settings.
 
     config : DictConfig
-        A dictionary containing SSL-related configurations.
-        - "ssl_ignore_cert_errors" (bool, optional): Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
-        - "ssl_ca_cert" (str, optional): Path to the CA certificate file for SSL verification.
-
-    Returns:
-    --------
-    None
-        The session is modified in place with the provided SSL settings.
-
-    Example:
-    --------
-    ```python
-    import requests
-
-    session = requests.Session()
-    config = {
-        "ssl_ignore_cert_errors": True,
-        "ssl_ca_cert": "/path/to/custom_ca.crt"
-    }
-
-    configure_session_for_ssl(session, config)
-
-    response = session.get("https://example.com")
-    print(response.status_code)
-    ```
+        A dictionary-like object containing SSL-related configuration:
+        - "ssl_verify" (bool or str, optional):
+          - If `False`, SSL verification is disabled (not recommended for production).
+          - If a string, it is treated as the path to a custom CA certificate file.
+          - If `True` or not provided, default SSL verification is used.
     """
-    ssl_ignore_cert_errors = config.get("ssl_ignore_cert_errors", False)
-    if ssl_ignore_cert_errors:
-        session.trust_env = False
-    ca_cert = config.get("ssl_ca_cert", None)
-    if ca_cert:
-        session.cert = ca_cert
+    ssl_verify = config.get("ssl_verify", None)
+
+    if ssl_verify is False:
+        logging.warning("Disabling ssl verification for session.")
+        session.verify = False
+    elif ssl_verify:
+        logging.info(f"Setting session.verify to {ssl_verify}")
+        session.verify = ssl_verify
 
 def remove_anchor(url: str) -> str:
     """Remove the anchor from a URL."""

--- a/crawlers/CRAWLERS.md
+++ b/crawlers/CRAWLERS.md
@@ -59,6 +59,7 @@ The `html_processing` configuration defines a set of special instructions that c
 `ray_workers`, if defined, specifies the number of ray workers to use for parallel processing. ray_workers=0 means dont use Ray. ray_workers=-1 means use all cores available.
 Note that ray with docker does not work on Mac M1/M2 machines.
 
+
 ### Database crawler
 
 ```yaml
@@ -200,7 +201,8 @@ The hackernews crawler can be used to crawl stories and comments from hacker new
 - `max_articles` specifies a limit to the number of stories crawled. 
 - `days_past` specifies the number of days backward to crawl, based on the top, new, ask, show and best story lists. For example with a value of 3 as in this example, the crawler will only index stories if the story or any comment in the story was published or updated in the last 3 days.
 - `days_past_comprehensive` if true, then the crawler performs a comprehensive search for ALL stories published within the last `days_past` days (which takes longer to run)
-
+- `ssl_trust_env` if false configures if the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
+- `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
 ### Docs crawler
 
 ```yaml
@@ -237,7 +239,9 @@ If `crawl_report` is true then the list of URLs associated with the removed docu
 The `html_processing` configuration defines a set of special instructions that can be used to ignore some content when extracting text from HTML:
 - `ids_to_remove` defines an (optional) list of HTML IDs that are ignored when extracting text from the page.
 - `tags_to_remove` defines an (optional) list of HTML semantic tags (like header, footer, nav, etc) that are ignored when extracting text from the page.
-
+- `ssl_trust_env` if false configures if the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
+- `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
+- 
 <br>**Note**: when specifying regular expressions it's recommended to use single quotes (as opposed to double quotes) to avoid issues with escape characters.
 
 ### Discourse crawler
@@ -302,7 +306,9 @@ The JIRA crawler indexes issues and comments into Vectara.
 - `jira_base_url`: the Jira base_url
 - `jira_username`: the user name that the crawler should use (`JIRA_PASSWORD` should be separately defined in the `secrets.toml` file)
 - `jira_jql`: a Jira JQL condition on the issues identified; in this example it is configured to only include items from the last year.
-
+- `ssl_trust_env` if false configures if the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
+- `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
+- 
 ### Confluence crawler
 
 ```yaml
@@ -314,6 +320,9 @@ The JIRA crawler indexes issues and comments into Vectara.
 
 This Python crawler is designed to pull content from a Confluence instance and index it into Vectara. It queries Confluence using a [CQL query](https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/), 
 retrieves pages and blogposts (including attachments if configured), extracts relevant metadata (e.g., labels, authors, space information).  
+
+- `ssl_trust_env` if false configures if the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
+- `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
 
 ### Twitter crawler
 
@@ -470,6 +479,8 @@ attachment API and index them in Vectara as well.
 - `servicenow_batch_size` (if present): The number of articles to fetch in each API call. Default: 100.
 - `servicenow_table` (if present):The ServiceNow table to query for articles. Default: `"kb_knowledge"`.
 - `servicenow_query` (if present): A query (e.g., `sysparm_query`) for filtering the knowledge-base articles returned by the ServiceNow API.
+- `ssl_trust_env` if false configures if the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
+- `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
 
 - **[Table API Reference](https://developer.servicenow.com/dev.do#!/reference/api/rome/rest/c_TableAPI)**  
   Contains details on the various endpoints, query parameters, and usage examples for retrieving data from ServiceNow tables.

--- a/crawlers/CRAWLERS.md
+++ b/crawlers/CRAWLERS.md
@@ -201,7 +201,7 @@ The hackernews crawler can be used to crawl stories and comments from hacker new
 - `max_articles` specifies a limit to the number of stories crawled. 
 - `days_past` specifies the number of days backward to crawl, based on the top, new, ask, show and best story lists. For example with a value of 3 as in this example, the crawler will only index stories if the story or any comment in the story was published or updated in the last 3 days.
 - `days_past_comprehensive` if true, then the crawler performs a comprehensive search for ALL stories published within the last `days_past` days (which takes longer to run)
-- `ssl_trust_env` if false configures if the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
+- `ssl_ignore_cert_errors` Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
 - `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
 ### Docs crawler
 
@@ -239,7 +239,7 @@ If `crawl_report` is true then the list of URLs associated with the removed docu
 The `html_processing` configuration defines a set of special instructions that can be used to ignore some content when extracting text from HTML:
 - `ids_to_remove` defines an (optional) list of HTML IDs that are ignored when extracting text from the page.
 - `tags_to_remove` defines an (optional) list of HTML semantic tags (like header, footer, nav, etc) that are ignored when extracting text from the page.
-- `ssl_trust_env` if false configures if the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
+- `ssl_ignore_cert_errors` Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
 - `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
 - 
 <br>**Note**: when specifying regular expressions it's recommended to use single quotes (as opposed to double quotes) to avoid issues with escape characters.
@@ -306,7 +306,7 @@ The JIRA crawler indexes issues and comments into Vectara.
 - `jira_base_url`: the Jira base_url
 - `jira_username`: the user name that the crawler should use (`JIRA_PASSWORD` should be separately defined in the `secrets.toml` file)
 - `jira_jql`: a Jira JQL condition on the issues identified; in this example it is configured to only include items from the last year.
-- `ssl_trust_env` if false configures if the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
+- `ssl_ignore_cert_errors` Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
 - `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
 - 
 ### Confluence crawler
@@ -321,7 +321,7 @@ The JIRA crawler indexes issues and comments into Vectara.
 This Python crawler is designed to pull content from a Confluence instance and index it into Vectara. It queries Confluence using a [CQL query](https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/), 
 retrieves pages and blogposts (including attachments if configured), extracts relevant metadata (e.g., labels, authors, space information).  
 
-- `ssl_trust_env` if false configures if the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
+- `ssl_ignore_cert_errors` Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
 - `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
 
 ### Twitter crawler
@@ -479,7 +479,7 @@ attachment API and index them in Vectara as well.
 - `servicenow_batch_size` (if present): The number of articles to fetch in each API call. Default: 100.
 - `servicenow_table` (if present):The ServiceNow table to query for articles. Default: `"kb_knowledge"`.
 - `servicenow_query` (if present): A query (e.g., `sysparm_query`) for filtering the knowledge-base articles returned by the ServiceNow API.
-- `ssl_trust_env` if false configures if the session should trust the environment settings. When set to False SSL will not be verified. Do not use in production.
+- `ssl_ignore_cert_errors` Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
 - `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
 
 - **[Table API Reference](https://developer.servicenow.com/dev.do#!/reference/api/rome/rest/c_TableAPI)**  

--- a/crawlers/CRAWLERS.md
+++ b/crawlers/CRAWLERS.md
@@ -201,8 +201,7 @@ The hackernews crawler can be used to crawl stories and comments from hacker new
 - `max_articles` specifies a limit to the number of stories crawled. 
 - `days_past` specifies the number of days backward to crawl, based on the top, new, ask, show and best story lists. For example with a value of 3 as in this example, the crawler will only index stories if the story or any comment in the story was published or updated in the last 3 days.
 - `days_past_comprehensive` if true, then the crawler performs a comprehensive search for ALL stories published within the last `days_past` days (which takes longer to run)
-- `ssl_ignore_cert_errors` Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
-- `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
+- `ssl_verify`  If `False`, SSL verification is disabled (not recommended for production). If a string, it is treated as the path to a custom CA certificate file. If `True` or not provided, default SSL verification is used.
 ### Docs crawler
 
 ```yaml
@@ -239,8 +238,7 @@ If `crawl_report` is true then the list of URLs associated with the removed docu
 The `html_processing` configuration defines a set of special instructions that can be used to ignore some content when extracting text from HTML:
 - `ids_to_remove` defines an (optional) list of HTML IDs that are ignored when extracting text from the page.
 - `tags_to_remove` defines an (optional) list of HTML semantic tags (like header, footer, nav, etc) that are ignored when extracting text from the page.
-- `ssl_ignore_cert_errors` Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
-- `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
+- `ssl_verify`  If `False`, SSL verification is disabled (not recommended for production). If a string, it is treated as the path to a custom CA certificate file. If `True` or not provided, default SSL verification is used.
 - 
 <br>**Note**: when specifying regular expressions it's recommended to use single quotes (as opposed to double quotes) to avoid issues with escape characters.
 
@@ -306,8 +304,7 @@ The JIRA crawler indexes issues and comments into Vectara.
 - `jira_base_url`: the Jira base_url
 - `jira_username`: the user name that the crawler should use (`JIRA_PASSWORD` should be separately defined in the `secrets.toml` file)
 - `jira_jql`: a Jira JQL condition on the issues identified; in this example it is configured to only include items from the last year.
-- `ssl_ignore_cert_errors` Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
-- `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
+- `ssl_verify`  If `False`, SSL verification is disabled (not recommended for production). If a string, it is treated as the path to a custom CA certificate file. If `True` or not provided, default SSL verification is used.
 - 
 ### Confluence crawler
 
@@ -321,8 +318,7 @@ The JIRA crawler indexes issues and comments into Vectara.
 This Python crawler is designed to pull content from a Confluence instance and index it into Vectara. It queries Confluence using a [CQL query](https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/), 
 retrieves pages and blogposts (including attachments if configured), extracts relevant metadata (e.g., labels, authors, space information).  
 
-- `ssl_ignore_cert_errors` Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
-- `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
+- `ssl_verify`  If `False`, SSL verification is disabled (not recommended for production). If a string, it is treated as the path to a custom CA certificate file. If `True` or not provided, default SSL verification is used.
 
 ### Twitter crawler
 
@@ -479,8 +475,7 @@ attachment API and index them in Vectara as well.
 - `servicenow_batch_size` (if present): The number of articles to fetch in each API call. Default: 100.
 - `servicenow_table` (if present):The ServiceNow table to query for articles. Default: `"kb_knowledge"`.
 - `servicenow_query` (if present): A query (e.g., `sysparm_query`) for filtering the knowledge-base articles returned by the ServiceNow API.
-- `ssl_ignore_cert_errors` Flag to disable ssl verification and ignore certificate errors. DO NOT RUN IN PRODUCTION.
-- `ssl_ca_cert` Path to a PEM encoded certificate file for the certificate authority.
+- `ssl_verify`  If `False`, SSL verification is disabled (not recommended for production). If a string, it is treated as the path to a custom CA certificate file. If `True` or not provided, default SSL verification is used.
 
 - **[Table API Reference](https://developer.servicenow.com/dev.do#!/reference/api/rome/rest/c_TableAPI)**  
   Contains details on the various endpoints, query parameters, and usage examples for retrieving data from ServiceNow tables.

--- a/crawlers/arxiv_crawler.py
+++ b/crawlers/arxiv_crawler.py
@@ -1,7 +1,8 @@
 import logging
 from core.crawler import Crawler
 import arxiv
-from core.utils import create_session_with_retries
+from core.utils import create_session_with_retries, configure_session_for_ssl
+
 
 def validate_category(category: str) -> bool:
     valid_categories = [
@@ -63,6 +64,7 @@ class ArxivCrawler(Crawler):
 
         # setup requests session and mount adapter to retry requests
         self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, self.cfg.arxiv_crawler)
 
         # define query for arxiv: search for the query in the "computer science" (cs.*) category
         query = f"cat:{category}.* AND " + ' AND '.join([f'all:{q}' for q in query_terms])

--- a/crawlers/confluence_crawler.py
+++ b/crawlers/confluence_crawler.py
@@ -7,7 +7,6 @@ import requests
 from furl import furl
 
 from core.crawler import Crawler
-from core.utils import create_session_with_retries
 
 
 import json
@@ -19,7 +18,7 @@ import requests
 from furl import furl
 
 from core.crawler import Crawler
-from core.utils import create_session_with_retries
+from core.utils import create_session_with_retries, configure_session_for_ssl
 
 
 def raise_for_status(response: requests.Response):
@@ -374,6 +373,7 @@ class ConfluenceCrawler(Crawler):
             self.cfg.confluence_crawler.confluence_password
         )
         self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, self.cfg.confluence_crawler)
         self.base_url = furl(self.cfg.confluence_crawler.confluence_base_url)
         self.user_cache = {}
         self.space_cache = {}

--- a/crawlers/discourse_crawler.py
+++ b/crawlers/discourse_crawler.py
@@ -2,7 +2,7 @@ import logging
 from core.crawler import Crawler
 from omegaconf import OmegaConf
 import json
-from core.utils import create_session_with_retries, html_to_text
+from core.utils import create_session_with_retries, html_to_text, configure_session_for_ssl
 from typing import List, Dict, Any
 from datetime import datetime
 
@@ -19,6 +19,7 @@ class DiscourseCrawler(Crawler):
         self.discourse_base_url = self.cfg.discourse_crawler.base_url
         self.discourse_api_key = self.cfg.discourse_crawler.discourse_api_key
         self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, self.cfg.discourse_crawler)
 
     # function to fetch the topics from the Discourse API
     def get_topics(self) -> List[Dict[str, Any]]:

--- a/crawlers/docs_crawler.py
+++ b/crawlers/docs_crawler.py
@@ -4,7 +4,8 @@ import logging
 from urllib.parse import urljoin, urlparse
 import re
 from collections import deque
-from core.utils import create_session_with_retries, binary_extensions, RateLimiter, setup_logging
+from core.utils import create_session_with_retries, binary_extensions, RateLimiter, setup_logging, \
+    configure_session_for_ssl
 from typing import Tuple, Set
 from core.indexer import Indexer
 import psutil
@@ -125,6 +126,7 @@ class DocsCrawler(Crawler):
         self.html_processing = self.cfg.docs_crawler.get('html_processing', {})
 
         self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, self.cfg.docs_crawler)
 
         source = self.cfg.docs_crawler.docs_system
         ray_workers = self.cfg.docs_crawler.get("ray_workers", 0)            # -1: use ray with ALL cores, 0: dont use ray

--- a/crawlers/edgar_crawler.py
+++ b/crawlers/edgar_crawler.py
@@ -11,7 +11,7 @@ from sec_downloader import Downloader
 from sec_downloader.types import RequestedFilings
 
 from core.crawler import Crawler
-from core.utils import create_session_with_retries, RateLimiter, ensure_empty_folder
+from core.utils import create_session_with_retries, RateLimiter, ensure_empty_folder, configure_session_for_ssl
 
 from io import StringIO
 from typing import Dict, List
@@ -73,6 +73,7 @@ class EdgarCrawler(Crawler):
         # build mapping of ticker to cik
         url = 'https://www.sec.gov/include/ticker.txt'
         self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, self.cfg.edgar_crawler)
         response = self.session.get(url, headers=get_headers())
         response.raise_for_status()
         data = StringIO(response.text)

--- a/crawlers/fmp_crawler.py
+++ b/crawlers/fmp_crawler.py
@@ -5,7 +5,8 @@ from typing import Dict, Any
 from omegaconf import OmegaConf, DictConfig
 
 from core.crawler import Crawler
-from core.utils import create_session_with_retries
+from core.utils import create_session_with_retries, configure_session_for_ssl
+
 
 # Crawler for financial information using the financialmodelingprep.com service
 # To use this crawler you have to have an fmp API_key in your secrets.toml profile
@@ -22,6 +23,7 @@ class FmpCrawler(Crawler):
         self.end_year = int(cfg_dict.fmp_crawler.end_year)
         self.api_key = cfg_dict.fmp_crawler.fmp_api_key
         self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, self.cfg.fmp_crawler)
         self.base_url = 'https://financialmodelingprep.com'
 
     def index_doc(self, document: Dict[str, Any]) -> bool:

--- a/crawlers/hackernews_crawler.py
+++ b/crawlers/hackernews_crawler.py
@@ -3,7 +3,7 @@ import json
 from omegaconf import OmegaConf
 import logging
 from core.crawler import Crawler
-from core.utils import html_to_text, create_session_with_retries
+from core.utils import html_to_text, create_session_with_retries, configure_session_for_ssl
 import datetime
 from typing import List
 
@@ -17,6 +17,7 @@ class HackernewsCrawler(Crawler):
         self.indexer.reindex = True     # always reindex with hackernews, since it depends on comments
         self.db_url = 'https://hacker-news.firebaseio.com/v0/'
         self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, self.cfg.hackernews_crawler)
 
     def get_comments(self, story: dict) -> List[str]:
         comments = []

--- a/crawlers/jira_crawler.py
+++ b/crawlers/jira_crawler.py
@@ -2,7 +2,8 @@ import logging
 import requests
 import json
 from core.crawler import Crawler
-from core.utils import create_session_with_retries
+from core.utils import create_session_with_retries, configure_session_for_ssl
+
 
 class JiraCrawler(Crawler):
 
@@ -10,6 +11,7 @@ class JiraCrawler(Crawler):
         self.jira_headers = { "Accept": "application/json" }
         self.jira_auth = (self.cfg.jira_crawler.jira_username, self.cfg.jira_crawler.jira_password)
         session = create_session_with_retries()
+        configure_session_for_ssl(session, self.cfg.jira_crawler)
 
         issue_count = 0
         startAt = 0

--- a/crawlers/mediawiki_crawler.py
+++ b/crawlers/mediawiki_crawler.py
@@ -6,7 +6,8 @@ from datetime import datetime, timedelta
 from mwviews.api import PageviewsClient
 
 from core.crawler import Crawler
-from core.utils import create_session_with_retries
+from core.utils import create_session_with_retries, configure_session_for_ssl
+
 
 class MediawikiCrawler(Crawler):
 
@@ -15,6 +16,7 @@ class MediawikiCrawler(Crawler):
         project = self.cfg.mediawiki_crawler.project
         n_pages = self.cfg.mediawiki_crawler.n_pages
         session = create_session_with_retries()
+        configure_session_for_ssl(session, self.cfg.mediawiki_crawler)
         if n_pages > 1000:
             n_pages = 1000
             logging.info(f"n_pages is too large, setting to 1000")

--- a/crawlers/pmc_crawler.py
+++ b/crawlers/pmc_crawler.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 import xmltodict
 from datetime import datetime, timedelta
 from typing import Set, List, Any
-from core.utils import html_to_text, create_session_with_retries, RateLimiter
+from core.utils import html_to_text, create_session_with_retries, RateLimiter, configure_session_for_ssl
 from core.crawler import Crawler
 
 from omegaconf import OmegaConf
@@ -37,6 +37,7 @@ class PmcCrawler(Crawler):
         self.crawled_pmc_ids: Set[str] = set()
         self.rate_limiter = RateLimiter(self.cfg.pmc_crawler.get("num_per_second", 3))
         self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, self.cfg.pmc_crawler)
 
     def index_papers_by_topic(self, topic: str, n_papers: int) -> None:
         """

--- a/crawlers/servicenow_crawler.py
+++ b/crawlers/servicenow_crawler.py
@@ -1,7 +1,7 @@
 import logging
 
 from core.crawler import Crawler
-from core.utils import create_session_with_retries
+from core.utils import create_session_with_retries, configure_session_for_ssl
 import os.path
 import json
 import tempfile
@@ -58,6 +58,7 @@ class ServicenowCrawler(Crawler):
             None: This method performs side effects (indexing) only and does not return a value.
         """
         self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, self.cfg.servicenow_crawler)
         self.base_url = furl(self.cfg.servicenow_crawler.servicenow_instance_url)
         self.servicenow_headers = {"Accept": "application/json"}
         self.servicenow_auth = (


### PR DESCRIPTION
For this one I have things configured so that you can have different certificate authorities for different things. For example I can see a customer connecting to ServiceNow which is cloud hosted but having an onprem instance of Vectara. In this case you most likely would want to use the default certificates for ServiceNow but use an internal certificate authority for the onprem instance of Vectara. This PR allows you to configure both.