### PR TITLE
Fix file type validation and error handling in SharePoint crawler and…

### DIFF
--- a/core/file_processor.py
+++ b/core/file_processor.py
@@ -51,6 +51,9 @@ class FileProcessor:
     
     def needs_pdf_splitting(self, filename: str) -> bool:
         """Check if PDF needs to be split due to size"""
+        # Only PDFs can be split
+        if not filename.lower().endswith('.pdf'):
+            return False
         max_pdf_size = int(self.cfg.doc_processing.get('max_pdf_size', 50))
         filesize_mb = get_file_size_in_MB(filename)
         return filesize_mb > max_pdf_size

--- a/crawlers/sharepoint_crawler.py
+++ b/crawlers/sharepoint_crawler.py
@@ -417,7 +417,7 @@ class SharepointCrawler(Crawler):
                     continue
                     
                 logger.info(f"Processing {file}")
-                filename, file_extension = os.path.splitext(file.name)
+                filename, file_extension = os.path.splitext(file.name.strip())
                 
                 if file_extension.lower() == ".zip":
                     metadata = {'url': self.download_url(file)}
@@ -435,7 +435,7 @@ class SharepointCrawler(Crawler):
                     metadata = {'url': self.download_url(file)}
                     if library_name:
                         metadata['library'] = library_name
-                    metadata['file_name'] = file.name
+                    metadata['file_name'] = file.name.strip()
                     
                     server_relative_url = self._get_sharepoint_property(file, 'ServerRelativeUrl')
                     if server_relative_url:


### PR DESCRIPTION
  - Added file type check in needs_pdf_splitting() to ensure only .pdf files are considered for splitting
  - Prevents non-PDF files (.pptx, .docx, etc.) from being passed to PdfReader, which was causing
  PdfStreamError crashes