### PR TITLE
Fix: capture HTML before script removal in scrapy extractor

### DIFF
--- a/core/scrapy_content_extractor.py
+++ b/core/scrapy_content_extractor.py
@@ -112,8 +112,7 @@ class ScrapyContentExtractor(WebExtractorBase):
 
             # Capture processed HTML before script/style removal so downstream
             # consumers (remove_boilerplate, metadata_extractor, etc.) see the
-            # html_processing removals but still have access to structured data
-            # like JSON-LD script tags.
+            # html_processing removals but still have access to structured data.
             result['html'] = str(soup)
 
             # Remove unwanted elements for text extraction

--- a/core/scrapy_content_extractor.py
+++ b/core/scrapy_content_extractor.py
@@ -110,7 +110,13 @@ class ScrapyContentExtractor(WebExtractorBase):
                     for element in soup.find_all(tag):
                         element.decompose()
 
-            # Remove unwanted elements
+            # Capture processed HTML before script/style removal so downstream
+            # consumers (remove_boilerplate, metadata_extractor, etc.) see the
+            # html_processing removals but still have access to structured data
+            # like JSON-LD script tags.
+            result['html'] = str(soup)
+
+            # Remove unwanted elements for text extraction
             for selector in ['script', 'style', 'header', 'footer', 'nav', 'aside']:
                 for element in soup.find_all(selector):
                     element.decompose()
@@ -119,10 +125,6 @@ class ScrapyContentExtractor(WebExtractorBase):
                 for tag in ['code', 'pre']:
                     for element in soup.find_all(tag):
                         element.decompose()
-
-            # Update result['html'] after all element removals so downstream consumers
-            # (remove_boilerplate, process_locally, etc.) see the processed HTML.
-            result['html'] = str(soup)
 
             # Determine content source: either from target_tag/target_class or default (entire document)
             target_tag = html_processing.get('target_tag') if html_processing else None


### PR DESCRIPTION
## Summary
- Moves `result['html'] = str(soup)` before the script/style element removal loop
- Downstream consumers (metadata extractors, remove_boilerplate) can now access structured data like JSON-LD `<script>` tags in the HTML
- Text extraction via `result['text']` is unaffected — scripts are still removed from the soup before `get_text()`

## Context
Commit `b5280c5` moved `result['html'] = str(soup)` after script removal, which inadvertently stripped JSON-LD metadata tags from the HTML passed to metadata extractors.

## Test plan
- [ ] Verify metadata extraction works for pages with JSON-LD `<script type="application/ld+json">` tags
- [ ] Verify `result['text']` does not contain script content
- [ ] Verify remove_boilerplate still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)