### PR TITLE
Fix table headers split into individual characters

### DIFF
--- a/core/document_builder.py
+++ b/core/document_builder.py
@@ -100,13 +100,17 @@ class DocumentBuilder:
                 logger.warning(f"Skipping table {inx} due to empty or missing summary")
                 continue
                 
+            headers = table['headers']
+            if headers and isinstance(headers[0], str):
+                headers = [headers]
+
             table_dict = {
                 'id': 'table_' + str(inx),
                 'title': table.get('title', ''),
                 'data': {
                     'headers': [
                         [{'text_value': str(col)} for col in header]
-                        for header in table['headers']
+                        for header in headers
                     ],
                     'rows': [
                         create_row_items(row) for row in table['rows']


### PR DESCRIPTION
## Summary
- When `table['headers']` is a flat list of strings (e.g. `['Col1', 'Col2']`), `_build_tables_array` iterated over each string then over its characters, producing single-character column names like `O`, `p`, `z`, `i`, `o`, `n`, `e` instead of `Opzione`
- Added detection for flat list vs list-of-lists format and wraps flat lists before iterating

## Test plan
- [ ] Verify tables with flat header lists render correct column names
- [ ] Verify tables with nested header lists (multi-row headers) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)