### PR TITLE
Split oversized structured sections to avoid 400 errors

### DIFF
--- a/core/document_builder.py
+++ b/core/document_builder.py
@@ -135,7 +135,7 @@ class DocumentBuilder:
     ) -> Dict[str, Any]:
         """Build document for core indexing"""
         # Check text size limits for core indexing
-        if any(len(text) > 16384 for text in texts):
+        if any(len(text) > MAX_SECTION_CHARS for text in texts):
             logger.warning(f"Document {document['id']} has segments too large for core indexing")
             return None
             
@@ -209,6 +209,8 @@ class DocumentBuilder:
             return [text]
 
         paragraphs = re.split(r'\n\s*\n', text)
+        if len(paragraphs) == 1 and '\n' in text:
+            paragraphs = re.split(r'\n+', text)
 
         chunks: List[str] = []
         current = ""

--- a/core/document_builder.py
+++ b/core/document_builder.py
@@ -1,9 +1,12 @@
 import hashlib
 import logging
+import re
 from typing import Dict, List, Any, Optional, Sequence
 from core.utils import create_row_items
 
 logger = logging.getLogger(__name__)
+
+MAX_SECTION_CHARS = 16384
 
 
 class DocumentBuilder:
@@ -158,19 +161,32 @@ class DocumentBuilder:
         doc_title: str,
         tables_array: List[Dict[str, Any]]
     ) -> Dict[str, Any]:
-        """Build document for structured indexing"""
+        """Build document for structured indexing.
+
+        Sections whose normalized text exceeds MAX_SECTION_CHARS are
+        automatically split into multiple sections so the Vectara API
+        does not reject the request.
+        """
         if doc_title and len(doc_title) > 0:
             document["title"] = self.normalize_text(doc_title)
-            
-        document["sections"] = [
-            {
-                "text": self.normalize_text(text),
-                "title": self.normalize_text(title),
-                "metadata": md
-            }
-            for text, title, md in zip(texts, titles, metadatas)
-        ]
-        
+
+        sections = []
+        for text, title, md in zip(texts, titles, metadatas):
+            normalized = self.normalize_text(text)
+            normalized_title = self.normalize_text(title)
+            if len(normalized) <= MAX_SECTION_CHARS:
+                sections.append({"text": normalized, "title": normalized_title, "metadata": md})
+            else:
+                chunks = self._split_text(normalized, MAX_SECTION_CHARS)
+                logger.info(
+                    f"Section text ({len(normalized)} chars) exceeds {MAX_SECTION_CHARS}, "
+                    f"split into {len(chunks)} sections for document {document.get('id', '?')}"
+                )
+                for chunk in chunks:
+                    sections.append({"text": chunk, "title": normalized_title, "metadata": md})
+
+        document["sections"] = sections
+
         if tables_array:
             document["sections"].append({
                 "text": '',
@@ -178,8 +194,74 @@ class DocumentBuilder:
                 "metadata": {},
                 "tables": tables_array
             })
-            
+
         return document
+
+    @staticmethod
+    def _split_text(text: str, max_chars: int) -> List[str]:
+        """Split *text* into chunks of at most *max_chars* characters.
+
+        Tries to break on paragraph boundaries (blank lines) first, then
+        falls back to sentence boundaries, and finally to a hard character
+        cut so that every returned chunk is within the limit.
+        """
+        if len(text) <= max_chars:
+            return [text]
+
+        paragraphs = re.split(r'\n\s*\n', text)
+
+        chunks: List[str] = []
+        current = ""
+
+        for para in paragraphs:
+            candidate = (current + "\n\n" + para).strip() if current else para
+            if len(candidate) <= max_chars:
+                current = candidate
+                continue
+
+            if current:
+                chunks.append(current)
+                current = ""
+
+            if len(para) <= max_chars:
+                current = para
+            else:
+                for sub in DocumentBuilder._split_by_sentences(para, max_chars):
+                    chunks.append(sub)
+
+        if current:
+            chunks.append(current)
+
+        return chunks
+
+    @staticmethod
+    def _split_by_sentences(text: str, max_chars: int) -> List[str]:
+        """Split text on sentence boundaries, with a hard-cut fallback."""
+        sentences = re.split(r'(?<=[.!?])\s+', text)
+
+        chunks: List[str] = []
+        current = ""
+
+        for sentence in sentences:
+            candidate = (current + " " + sentence).strip() if current else sentence
+            if len(candidate) <= max_chars:
+                current = candidate
+                continue
+
+            if current:
+                chunks.append(current)
+                current = ""
+
+            if len(sentence) <= max_chars:
+                current = sentence
+            else:
+                for i in range(0, len(sentence), max_chars):
+                    chunks.append(sentence[i:i + max_chars])
+
+        if current:
+            chunks.append(current)
+
+        return chunks
     
     def create_image_document(
         self,

--- a/core/document_builder.py
+++ b/core/document_builder.py
@@ -208,15 +208,17 @@ class DocumentBuilder:
         if len(text) <= max_chars:
             return [text]
 
+        paragraph_joiner = "\n\n"
         paragraphs = re.split(r'\n\s*\n', text)
         if len(paragraphs) == 1 and '\n' in text:
             paragraphs = re.split(r'\n+', text)
+            paragraph_joiner = "\n"
 
         chunks: List[str] = []
         current = ""
 
         for para in paragraphs:
-            candidate = (current + "\n\n" + para).strip() if current else para
+            candidate = (current + paragraph_joiner + para).strip() if current else para
             if len(candidate) <= max_chars:
                 current = candidate
                 continue

--- a/tests/test_document_builder.py
+++ b/tests/test_document_builder.py
@@ -60,7 +60,7 @@ class TestBuildStructuredDocument(unittest.TestCase):
     """Tests for auto-splitting in _build_structured_document."""
 
     def setUp(self):
-        self.builder = DocumentBuilder({})
+        self.builder = DocumentBuilder({}, normalize_text_func=lambda t: t)
 
     def test_small_section_not_split(self):
         doc = {"id": "test", "metadata": {}}

--- a/tests/test_document_builder.py
+++ b/tests/test_document_builder.py
@@ -1,0 +1,87 @@
+import unittest
+from core.document_builder import DocumentBuilder, MAX_SECTION_CHARS
+
+
+class TestSplitText(unittest.TestCase):
+    """Tests for DocumentBuilder._split_text and _split_by_sentences."""
+
+    def test_short_text_unchanged(self):
+        chunks = DocumentBuilder._split_text("hello world", MAX_SECTION_CHARS)
+        self.assertEqual(chunks, ["hello world"])
+
+    def test_split_on_paragraph_boundaries(self):
+        para = "A" * 10000
+        text = para + "\n\n" + para
+        chunks = DocumentBuilder._split_text(text, MAX_SECTION_CHARS)
+        self.assertEqual(len(chunks), 2)
+        self.assertTrue(all(len(c) <= MAX_SECTION_CHARS for c in chunks))
+
+    def test_single_newline_fallback(self):
+        line = "B" * 10000
+        text = line + "\n" + line
+        chunks = DocumentBuilder._split_text(text, MAX_SECTION_CHARS)
+        self.assertEqual(len(chunks), 2)
+        self.assertTrue(all(len(c) <= MAX_SECTION_CHARS for c in chunks))
+
+    def test_split_on_sentence_boundaries(self):
+        sentences = ". ".join(["Sentence number " + str(i) for i in range(1000)])
+        chunks = DocumentBuilder._split_text(sentences, MAX_SECTION_CHARS)
+        self.assertTrue(all(len(c) <= MAX_SECTION_CHARS for c in chunks))
+        self.assertGreater(len(chunks), 1)
+
+    def test_hard_cut_fallback(self):
+        text = "A" * 50000
+        chunks = DocumentBuilder._split_text(text, MAX_SECTION_CHARS)
+        self.assertEqual(len(chunks), 4)
+        self.assertTrue(all(len(c) <= MAX_SECTION_CHARS for c in chunks))
+        self.assertEqual("".join(chunks), text)
+
+    def test_content_preserved_after_paragraph_split(self):
+        para1 = "X" * 10000
+        para2 = "Y" * 10000
+        para3 = "Z" * 5000
+        text = para1 + "\n\n" + para2 + "\n\n" + para3
+        chunks = DocumentBuilder._split_text(text, MAX_SECTION_CHARS)
+        self.assertTrue(all(len(c) <= MAX_SECTION_CHARS for c in chunks))
+        joined = "\n\n".join(chunks)
+        self.assertIn(para1, joined)
+        self.assertIn(para2, joined)
+        self.assertIn(para3, joined)
+
+    def test_small_paragraphs_grouped(self):
+        paras = ["Para " + str(i) for i in range(10)]
+        text = "\n\n".join(paras)
+        chunks = DocumentBuilder._split_text(text, MAX_SECTION_CHARS)
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0], text)
+
+
+class TestBuildStructuredDocument(unittest.TestCase):
+    """Tests for auto-splitting in _build_structured_document."""
+
+    def setUp(self):
+        self.builder = DocumentBuilder({})
+
+    def test_small_section_not_split(self):
+        doc = {"id": "test", "metadata": {}}
+        result = self.builder._build_structured_document(
+            doc, ["short text"], ["title"], [{}], "Doc", []
+        )
+        self.assertEqual(len(result["sections"]), 1)
+        self.assertEqual(result["sections"][0]["text"], "short text")
+
+    def test_large_section_auto_split(self):
+        doc = {"id": "test", "metadata": {}}
+        big_text = "word " * 5000  # ~25000 chars
+        result = self.builder._build_structured_document(
+            doc, [big_text], ["title"], [{}], "Doc", []
+        )
+        self.assertGreater(len(result["sections"]), 1)
+        self.assertTrue(all(len(s["text"]) <= MAX_SECTION_CHARS for s in result["sections"]))
+        for s in result["sections"]:
+            self.assertEqual(s["title"], "title")
+            self.assertEqual(s["metadata"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Structured document sections exceeding 16,384 characters now auto-split into multiple sections within the same document
- Splits on paragraph boundaries first, then sentence boundaries, with hard character cut as fallback
- Fixes 400 (Bad Request) errors when indexing large web pages via `index_url` → `index_segments`

## Test plan
- [x] Unit tested splitting logic (paragraph, sentence, hard-cut boundaries)
- [ ] Verify previously-failing large techdocs URLs now index successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)