### PR TITLE
Reduce MAX_SECTION_CHARS to 12000 for JSON encoding headroom

### DIFF
--- a/core/document_builder.py
+++ b/core/document_builder.py
@@ -6,7 +6,7 @@ from core.utils import create_row_items
 
 logger = logging.getLogger(__name__)
 
-MAX_SECTION_CHARS = 16384
+MAX_SECTION_CHARS = 12000
 
 
 class DocumentBuilder:

--- a/tests/test_document_builder.py
+++ b/tests/test_document_builder.py
@@ -32,7 +32,8 @@ class TestSplitText(unittest.TestCase):
     def test_hard_cut_fallback(self):
         text = "A" * 50000
         chunks = DocumentBuilder._split_text(text, MAX_SECTION_CHARS)
-        self.assertEqual(len(chunks), 4)
+        expected_chunks = (50000 + MAX_SECTION_CHARS - 1) // MAX_SECTION_CHARS
+        self.assertEqual(len(chunks), expected_chunks)
         self.assertTrue(all(len(c) <= MAX_SECTION_CHARS for c in chunks))
         self.assertEqual("".join(chunks), text)
 


### PR DESCRIPTION
## Summary
- Reduces `MAX_SECTION_CHARS` from 16,384 to 12,000 to account for JSON escaping overhead
- 16,384-char sections with special characters (quotes, backslashes, newlines) expand during JSON serialization and exceed the Vectara API's 16,384 document part limit
- 12,000 leaves ~27% headroom, confirmed needed by real-world CVE pages hitting 18,103 chars after encoding

## Test plan
- [x] Updated hard-cut test to be constant-agnostic
- [ ] Verify previously-failing techdocs CVE URLs now index successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)