### PR TITLE
Add Wolken KB crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Vectara is the trusted GenAI platform providing simple [APIs](https://docs.vecta
 * RSS feeds
 * Jira tickets
 * Notion notes
+* Wolken KB articles
 * Docusaurus documentation sites
 * Slack
 * And many others...
@@ -501,6 +502,16 @@ MOTION_API_KEY="<YOUR-NOTION-API-KEY>
 The use of the `toml` standard allows easy secrets management when you have multiple crawl jobs that may not share the same secrets. For example when you have a different Vectara API key for indexing differnet corpora.
 
 Many of the crawlers have their own secrets, for example Notion, Discourse, Jira, or GitHub. These are also kept in the `secrets.toml` file in the appropriate section and need to be all upper case (e.g. `NOTION_API_KEY` or `JIRA_PASSWORD`).
+
+For the Wolken KB crawler, add these secrets prefixed with `WOLKEN_`:
+```
+WOLKEN_API_ENDPOINT="https://api-mycompany.wolkenservicedesk.com"
+WOLKEN_DOMAIN="mycompany"
+WOLKEN_CLIENT_ID="your-client-id"
+WOLKEN_SERVICE_ACCOUNT="service@mycompany.com"
+WOLKEN_AUTH_CODE="Basic ..."
+WOLKEN_REFRESH_TOKEN="your-refresh-token"
+```
 
 If you are using the table summarization, image summarization or contextual retreival features, 
 you have to provide your own LLM key (either OPENAI_API_KEY or ANTHROPIC_API_KEY). 

--- a/README.md
+++ b/README.md
@@ -503,8 +503,10 @@ The use of the `toml` standard allows easy secrets management when you have mult
 
 Many of the crawlers have their own secrets, for example Notion, Discourse, Jira, or GitHub. These are also kept in the `secrets.toml` file in the appropriate section and need to be all upper case (e.g. `NOTION_API_KEY` or `JIRA_PASSWORD`).
 
-For the Wolken KB crawler, add these secrets prefixed with `WOLKEN_`:
+For the Wolken KB crawler, add these secrets prefixed with `WOLKEN_` under your profile section:
 ```
+[profile1]
+api_key="<VECTARA-API-KEY>"
 WOLKEN_API_ENDPOINT="https://api-mycompany.wolkenservicedesk.com"
 WOLKEN_DOMAIN="mycompany"
 WOLKEN_CLIENT_ID="your-client-id"

--- a/config/wolken-kb.yaml
+++ b/config/wolken-kb.yaml
@@ -1,0 +1,36 @@
+vectara:
+  corpus_key: wolken-kb
+  reindex: false
+  create_corpus: true
+
+crawling:
+  crawler_type: wolken
+
+wolken_crawler:
+  # API endpoint for your Wolken instance (e.g. https://api-mycompany.wolkenservicedesk.com)
+  api_endpoint: ""
+  # Domain name for the Wolken instance
+  domain: ""
+  # OAuth client ID
+  client_id: ""
+  # Service account email
+  service_account: ""
+  # Basic auth code for token endpoint (e.g. "Basic ...")
+  auth_code: ""
+  # Refresh token for authentication
+  refresh_token: ""
+
+  # Optional: filter categories by KB source ID
+  # kb_source_id: 1
+
+  # Number of items per API page
+  batch_size: 100
+
+  # Content fields to extract from article details (in order).
+  # Available fields: introduction, cause, environment, resolution, additionalInfo, internalNotes
+  content_fields:
+    - introduction
+    - cause
+    - environment
+    - resolution
+    - additionalInfo

--- a/crawlers/wolken_crawler.py
+++ b/crawlers/wolken_crawler.py
@@ -32,6 +32,11 @@ def clean_html(text: str) -> str:
     return text
 
 
+def _str_or_empty(v) -> str:
+    """Convert a value to string, mapping None to empty string (avoids 'None' literal in metadata)."""
+    return "" if v is None else str(v)
+
+
 class WolkenCrawler(Crawler):
 
     def __init__(self, cfg, endpoint, corpus_key, api_key):
@@ -82,7 +87,9 @@ class WolkenCrawler(Crawler):
             raise ValueError("No access_token in response")
 
         expires_in = int(token_data.get("expires_in", 3600))
-        self.token_expires_at = time.time() + expires_in - 120
+        # Use a 120s safety margin, but for short-lived tokens degrade to half the lifetime
+        # so we don't refresh on every request.
+        self.token_expires_at = time.time() + max(expires_in - 120, expires_in / 2)
         logger.info("Access token obtained (expires_in=%s)", expires_in)
 
     def _api_headers(self) -> dict:
@@ -264,11 +271,11 @@ class WolkenCrawler(Crawler):
                         "source": "wolken_kb",
                         "article_id": str(article_id),
                         "category": cat_name,
-                        "created_time": details.get("createdTime", ""),
-                        "updated_time": details.get("updatedTime", ""),
-                        "status_id": str(details.get("statusId", "")),
-                        "validation_status_id": str(other_info.get("validationStatusId", "")),
-                        "published_date": other_info.get("publishedDate", ""),
+                        "created_time": _str_or_empty(details.get("createdTime")),
+                        "updated_time": _str_or_empty(details.get("updatedTime")),
+                        "status_id": _str_or_empty(details.get("statusId")),
+                        "validation_status_id": _str_or_empty(other_info.get("validationStatusId")),
+                        "published_date": _str_or_empty(other_info.get("publishedDate")),
                     }
 
                     # Build article URL if available

--- a/crawlers/wolken_crawler.py
+++ b/crawlers/wolken_crawler.py
@@ -1,0 +1,308 @@
+"""
+Wolken KB Crawler
+
+Crawls Knowledge Base articles from Wolken ServiceDesk using the public KB REST API
+and indexes them into Vectara.
+
+API docs: https://developer-beta.wolkensoftware.com/kb/docs.html
+
+Flow:
+1. Authenticate via refresh_token to get access_token
+2. Fetch KB categories (paginated)
+3. For each category, fetch articles (paginated)
+4. For each article, fetch full details and index into Vectara
+"""
+
+import logging
+import re
+import time
+
+import requests
+from core.crawler import Crawler
+
+logger = logging.getLogger(__name__)
+
+
+def clean_html(text: str) -> str:
+    """Strip HTML tags and collapse whitespace."""
+    if not text:
+        return ""
+    text = re.sub(r'<[^>]+>', ' ', text)
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+
+
+class WolkenCrawler(Crawler):
+
+    def __init__(self, cfg, endpoint, corpus_key, api_key):
+        super().__init__(cfg, endpoint, corpus_key, api_key)
+
+        crawler_cfg = cfg.get("wolken_crawler", {})
+
+        self.api_endpoint = crawler_cfg.get("api_endpoint", "")
+        self.domain = crawler_cfg.get("domain", "")
+        self.client_id = crawler_cfg.get("client_id", "")
+        self.service_account = crawler_cfg.get("service_account", "")
+        self.auth_code = crawler_cfg.get("auth_code", "")
+        self.refresh_token_value = crawler_cfg.get("refresh_token", "")
+
+        self.batch_size = crawler_cfg.get("batch_size", 100)
+        self.kb_source_id = crawler_cfg.get("kb_source_id", None)
+
+        # Content fields to extract from articleOtherInfo
+        self.content_fields = crawler_cfg.get("content_fields", [
+            "introduction", "cause", "environment", "resolution", "additionalInfo"
+        ])
+
+        self.access_token = None
+        self.token_expires_at = 0
+        self.session = requests.Session()
+
+    def _ensure_token(self):
+        """Refresh the access token if expired or missing."""
+        if self.access_token and time.time() < self.token_expires_at:
+            return
+
+        url = f"{self.api_endpoint}/wolken-secure/oauth/token"
+        headers = {
+            "Authorization": self.auth_code,
+            "domain": self.domain,
+        }
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": self.refresh_token_value,
+        }
+
+        response = self.session.post(url, headers=headers, data=data, timeout=30)
+        response.raise_for_status()
+
+        token_data = response.json()
+        self.access_token = token_data.get("access_token")
+        if not self.access_token:
+            raise ValueError("No access_token in response")
+
+        expires_in = int(token_data.get("expires_in", 3600))
+        self.token_expires_at = time.time() + expires_in - 120
+        logger.info("Access token obtained (expires_in=%s)", expires_in)
+
+    def _api_headers(self) -> dict:
+        """Return headers for authenticated KB API calls."""
+        self._ensure_token()
+        return {
+            "clientId": self.client_id,
+            "domain": self.domain,
+            "serviceAccount": self.service_account,
+            "Authorization": f"Bearer {self.access_token}",
+            "accept": "application/json",
+        }
+
+    def _get(self, path: str, params: dict = None) -> dict:
+        """Make an authenticated GET request to the Wolken KB API."""
+        url = f"{self.api_endpoint}/wolken-secure{path}"
+        response = self.session.get(url, headers=self._api_headers(), params=params, timeout=60)
+
+        if response.status_code == 401:
+            logger.warning("Got 401, refreshing token and retrying")
+            self.access_token = None
+            response = self.session.get(url, headers=self._api_headers(), params=params, timeout=60)
+
+        response.raise_for_status()
+        return response.json()
+
+    def _get_categories(self) -> list:
+        """Fetch all KB categories with pagination."""
+        categories = []
+        offset = 0
+        limit = self.batch_size
+
+        while True:
+            params = {}
+            if self.kb_source_id is not None:
+                params["kbSourceId"] = self.kb_source_id
+
+            result = self._get(f"/api/kb/categories/{limit}/{offset}", params=params)
+            data = result.get("data", [])
+            if not data:
+                break
+
+            if isinstance(data, dict):
+                categories.append(data)
+                break
+            categories.extend(data)
+
+            if len(data) < limit:
+                break
+            offset += limit
+
+        logger.info("Found %d KB categories", len(categories))
+        return categories
+
+    def _get_articles_for_category(self, cat_id: int) -> list:
+        """Fetch all articles for a given category with pagination."""
+        articles = []
+        offset = 0
+        limit = self.batch_size
+
+        while True:
+            result = self._get(f"/api/kb/articles/{cat_id}/{limit}/{offset}")
+            data = result.get("data", [])
+            if not data:
+                break
+
+            if isinstance(data, dict):
+                articles.append(data)
+                break
+            articles.extend(data)
+
+            if len(data) < limit:
+                break
+            offset += limit
+
+        return articles
+
+    def _get_article_details(self, article_id: int) -> dict:
+        """Fetch full article details by ID."""
+        result = self._get(f"/api/kb/articles/{article_id}")
+        data = result.get("data", {})
+        if isinstance(data, list) and len(data) > 0:
+            return data[0]
+        return data if isinstance(data, dict) else {}
+
+    def _build_article_content(self, details: dict) -> list:
+        """
+        Extract content sections from article details.
+        Returns list of (section_title, section_text) tuples.
+        """
+        other_info = details.get("articleOtherInfo", {}) or {}
+        sections = []
+
+        field_titles = {
+            "introduction": "Introduction",
+            "cause": "Cause",
+            "environment": "Environment",
+            "resolution": "Resolution",
+            "additionalInfo": "Additional Info",
+            "internalNotes": "Internal Notes",
+        }
+
+        for field in self.content_fields:
+            raw = other_info.get(field, "") or ""
+            text = clean_html(raw)
+            if text:
+                title = field_titles.get(field, field.replace("_", " ").title())
+                sections.append((title, text))
+
+        # Fallback: use description or summary if no content fields found
+        if not sections:
+            desc = clean_html(details.get("description", "") or "")
+            if desc:
+                sections.append(("Description", desc))
+            summary = clean_html(details.get("summary", "") or "")
+            if summary:
+                sections.append(("Summary", summary))
+
+        return sections
+
+    def crawl(self) -> None:
+        """Main crawl loop: categories → articles → details → index."""
+        categories = self._get_categories()
+
+        indexed_ids = set()
+        if self.tracker and not self.cfg.vectara.get("reindex", False):
+            indexed_ids = self.tracker.get_indexed_ids()
+
+        total_indexed = 0
+        total_failed = 0
+        total_skipped = 0
+
+        for cat in categories:
+            cat_id = cat.get("catId")
+            cat_name = cat.get("catName", "Unknown")
+            if not cat_id:
+                continue
+
+            logger.info("Fetching articles for category '%s' (id=%s)", cat_name, cat_id)
+            articles = self._get_articles_for_category(cat_id)
+            logger.info("Found %d articles in category '%s'", len(articles), cat_name)
+
+            for article in articles:
+                self.check_shutdown()
+
+                article_id = article.get("articleId")
+                article_title = article.get("articleTitle", "Untitled")
+                if not article_id:
+                    continue
+
+                doc_id = f"wolken-kb-{article_id}"
+
+                if doc_id in indexed_ids:
+                    total_skipped += 1
+                    continue
+
+                try:
+                    details = self._get_article_details(article_id)
+                    if not details:
+                        logger.warning("No details for article %s, skipping", article_id)
+                        total_failed += 1
+                        if self.tracker:
+                            self.tracker.track_failed(doc_id, title=article_title, error="No details returned")
+                        continue
+
+                    title = details.get("articleTitle", article_title)
+                    content_sections = self._build_article_content(details)
+
+                    if not content_sections:
+                        logger.info("Article %s has no content, skipping", article_id)
+                        total_skipped += 1
+                        if self.tracker:
+                            self.tracker.track_skipped(doc_id, title=title, reason="No content")
+                        continue
+
+                    # Build metadata
+                    other_info = details.get("articleOtherInfo", {}) or {}
+                    metadata = {
+                        "source": "wolken_kb",
+                        "article_id": str(article_id),
+                        "category": cat_name,
+                        "created_time": details.get("createdTime", ""),
+                        "updated_time": details.get("updatedTime", ""),
+                        "status_id": str(details.get("statusId", "")),
+                        "validation_status_id": str(other_info.get("validationStatusId", "")),
+                        "published_date": other_info.get("publishedDate", ""),
+                    }
+
+                    # Build article URL if available
+                    url_name = details.get("articleUrlName", "")
+                    if url_name:
+                        metadata["url"] = url_name
+
+                    texts = [text for _, text in content_sections]
+                    titles = [section_title for section_title, _ in content_sections]
+
+                    succeeded = self.indexer.index_segments(
+                        doc_id=doc_id,
+                        texts=texts,
+                        titles=titles,
+                        doc_metadata=metadata,
+                        doc_title=title,
+                    )
+
+                    if succeeded:
+                        total_indexed += 1
+                        if self.tracker:
+                            self.tracker.track_indexed(doc_id, title=title)
+                    else:
+                        total_failed += 1
+                        if self.tracker:
+                            self.tracker.track_failed(doc_id, title=title, error="Indexing failed")
+
+                except Exception as e:
+                    logger.warning("Failed to process article %s: %s", article_id, e)
+                    total_failed += 1
+                    if self.tracker:
+                        self.tracker.track_failed(doc_id, title=article_title, error=str(e))
+
+        logger.info(
+            "Wolken KB crawl complete: indexed=%d, failed=%d, skipped=%d",
+            total_indexed, total_failed, total_skipped,
+        )

--- a/docs/wolken-kb-setup.md
+++ b/docs/wolken-kb-setup.md
@@ -1,0 +1,193 @@
+# Wolken KB Crawler Setup Guide
+
+This guide explains how to set up the Wolken KB crawler to index Knowledge Base articles from [Wolken ServiceDesk](https://www.wolkensoftware.com/) into Vectara.
+
+## Overview
+
+The Wolken KB crawler uses the [public Wolken Knowledge Base REST API](https://developer-beta.wolkensoftware.com/kb/docs.html) to fetch and index KB articles. It:
+
+1. Authenticates using OAuth2 refresh token flow
+2. Fetches all KB categories
+3. For each category, fetches all articles (with pagination)
+4. For each article, fetches the full details (introduction, cause, resolution, etc.)
+5. Indexes each article as a structured document in Vectara
+
+## Prerequisites
+
+You need the following from your Wolken ServiceDesk instance:
+
+| Credential | Description |
+|---|---|
+| **API Endpoint** | Base URL for your instance (e.g. `https://api-mycompany.wolkenservicedesk.com`) |
+| **Domain** | Your Wolken tenant domain name |
+| **Client ID** | OAuth client ID associated with the service account |
+| **Service Account** | Service account email for API access |
+| **Auth Code** | Basic authentication code for the token endpoint (e.g. `Basic dXNlcjpwYXNz`) |
+| **Refresh Token** | OAuth refresh token for obtaining access tokens |
+
+Contact your Wolken administrator to obtain these credentials.
+
+## Configuration
+
+### 1. Create the config file
+
+Create a YAML config file (e.g. `config/wolken-kb.yaml`):
+
+```yaml
+vectara:
+  corpus_key: wolken-kb
+  reindex: false
+  create_corpus: true
+
+crawling:
+  crawler_type: wolken
+
+wolken_crawler:
+  # API endpoint for your Wolken instance
+  api_endpoint: "https://api-mycompany.wolkenservicedesk.com"
+  # Domain name
+  domain: "mycompany"
+  # OAuth client ID
+  client_id: "your-client-id"
+  # Service account email
+  service_account: "service@mycompany.com"
+  # Basic auth code for token endpoint
+  auth_code: "Basic ..."
+  # Refresh token
+  refresh_token: "your-refresh-token"
+
+  # Number of items per API page (default: 100)
+  batch_size: 100
+
+  # Optional: filter by KB source ID
+  # kb_source_id: 1
+
+  # Content fields to extract from articles (in order)
+  content_fields:
+    - introduction
+    - cause
+    - environment
+    - resolution
+    - additionalInfo
+```
+
+### 2. Add secrets to `secrets.toml`
+
+Instead of putting credentials directly in the config file, you can use `secrets.toml`:
+
+```toml
+[default]
+api_key = "your-vectara-api-key"
+WOLKEN_API_ENDPOINT = "https://api-mycompany.wolkenservicedesk.com"
+WOLKEN_DOMAIN = "mycompany"
+WOLKEN_CLIENT_ID = "your-client-id"
+WOLKEN_SERVICE_ACCOUNT = "service@mycompany.com"
+WOLKEN_AUTH_CODE = "Basic ..."
+WOLKEN_REFRESH_TOKEN = "your-refresh-token"
+```
+
+All keys prefixed with `WOLKEN_` are automatically mapped to the `wolken_crawler` config section with the prefix stripped and lowercased. For example, `WOLKEN_API_ENDPOINT` becomes `wolken_crawler.api_endpoint`.
+
+When using `secrets.toml`, you can leave the credential fields empty in the YAML config:
+
+```yaml
+wolken_crawler:
+  api_endpoint: ""
+  domain: ""
+  client_id: ""
+  service_account: ""
+  auth_code: ""
+  refresh_token: ""
+  batch_size: 100
+  content_fields:
+    - introduction
+    - cause
+    - environment
+    - resolution
+    - additionalInfo
+```
+
+### 3. Run the crawler
+
+**Using Docker:**
+
+```bash
+./run.sh config/wolken-kb.yaml default
+```
+
+**Using the CLI directly:**
+
+```bash
+python ingest.py --config-file config/wolken-kb.yaml --profile default
+```
+
+## Configuration Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `api_endpoint` | string | required | Base URL of your Wolken instance |
+| `domain` | string | required | Wolken tenant domain |
+| `client_id` | string | required | OAuth client ID |
+| `service_account` | string | required | Service account email |
+| `auth_code` | string | required | Basic auth header for token endpoint |
+| `refresh_token` | string | required | OAuth refresh token |
+| `batch_size` | integer | 100 | Number of items per API page |
+| `kb_source_id` | integer | none | Filter categories by KB source ID |
+| `content_fields` | list | see below | Fields to extract from article details |
+
+### Content Fields
+
+The `content_fields` option controls which fields are extracted from the article's `articleOtherInfo` and in what order. Available fields:
+
+| Field | Description |
+|---|---|
+| `introduction` | Article introduction/overview |
+| `cause` | Root cause description |
+| `environment` | Environment/context information |
+| `resolution` | Resolution/fix steps |
+| `additionalInfo` | Additional information |
+| `internalNotes` | Internal notes (may not be visible externally) |
+
+Default: `["introduction", "cause", "environment", "resolution", "additionalInfo"]`
+
+Each non-empty field becomes a separate section in the Vectara document with the field name as the section title.
+
+If none of the configured fields have content, the crawler falls back to the article's `description` and `summary` fields.
+
+## Document Structure
+
+Each article is indexed as a Vectara document with:
+
+- **Document ID**: `wolken-kb-{articleId}`
+- **Title**: Article title from Wolken
+- **Sections**: One per content field (Introduction, Cause, Resolution, etc.)
+- **Metadata**:
+  - `source`: "wolken_kb"
+  - `article_id`: Wolken article ID
+  - `category`: KB category name
+  - `created_time`: Article creation timestamp
+  - `updated_time`: Last update timestamp
+  - `status_id`: Article status
+  - `validation_status_id`: Validation status
+  - `published_date`: Publication date
+  - `url`: Article URL (if available)
+
+## Resume Support
+
+The crawler supports resume via the `reindex` flag:
+
+- `reindex: false` — On restart, skip articles that were already indexed (uses crawl tracking if enabled)
+- `reindex: true` — Re-index all articles from scratch
+
+## API Reference
+
+The crawler uses the following Wolken KB REST API endpoints:
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `POST` | `/wolken-secure/oauth/token` | Get access token via refresh token |
+| `GET` | `/wolken-secure/api/kb/categories/{limit}/{offset}` | List KB categories |
+| `GET` | `/wolken-secure/api/kb/articles/{catId}/{limit}/{offset}` | List articles by category |
+| `GET` | `/wolken-secure/api/kb/articles/{articleId}` | Get full article details |
+
+Full API documentation: https://developer-beta.wolkensoftware.com/kb/docs.html

--- a/ingest.py
+++ b/ingest.py
@@ -221,6 +221,9 @@ def update_environment(cfg: DictConfig, source: str, env_dict) -> None:
         if k.startswith('aws_'):
             update_omega_conf(cfg, reason, f's3_crawler.{k.lower()}', v)
             continue
+        if k.startswith('WOLKEN_'):
+            update_omega_conf(cfg, reason, f'wolken_crawler.{k[7:].lower()}', v)
+            continue
 
         patterns = {
             'VECTARA_(.+)': 'vectara',

--- a/tests/test_wolken_crawler.py
+++ b/tests/test_wolken_crawler.py
@@ -1,0 +1,253 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Mock heavy dependencies before importing the crawler
+for mod in [
+    "cairosvg", "whisper", "pdf2image",
+    "playwright", "playwright.sync_api",
+    "core.summary", "core.indexer", "core.web_content_extractor",
+]:
+    if mod not in sys.modules:
+        sys.modules[mod] = MagicMock()
+
+from crawlers.wolken_crawler import WolkenCrawler, clean_html
+
+
+class TestCleanHtml(unittest.TestCase):
+
+    def test_strips_tags(self):
+        self.assertEqual(clean_html("<p>Hello <b>world</b></p>"), "Hello world")
+
+    def test_collapses_whitespace(self):
+        self.assertEqual(clean_html("  Hello   world  "), "Hello world")
+
+    def test_empty_string(self):
+        self.assertEqual(clean_html(""), "")
+
+    def test_none(self):
+        self.assertEqual(clean_html(None), "")
+
+    def test_no_tags(self):
+        self.assertEqual(clean_html("Just plain text"), "Just plain text")
+
+
+def _make_crawler(**overrides):
+    """Create a WolkenCrawler with mocked dependencies."""
+    cfg = {
+        "vectara": {
+            "endpoint": "https://api.vectara.io",
+            "reindex": False,
+        },
+        "wolken_crawler": {
+            "api_endpoint": "https://api-test.wolkenservicedesk.com",
+            "domain": "testdomain",
+            "client_id": "test-client",
+            "service_account": "svc@test.com",
+            "auth_code": "Basic dGVzdA==",
+            "refresh_token": "test-refresh-token",
+            "batch_size": 100,
+            "content_fields": ["introduction", "cause", "resolution"],
+        },
+    }
+    cfg.update(overrides)
+
+    from omegaconf import OmegaConf
+    omega_cfg = OmegaConf.create(cfg)
+
+    with patch("crawlers.wolken_crawler.Crawler.__init__", return_value=None):
+        crawler = WolkenCrawler.__new__(WolkenCrawler)
+        crawler.cfg = omega_cfg
+        crawler.indexer = MagicMock()
+        crawler.tracker = None
+        crawler.shutdown_requested = False
+        crawler.verbose = False
+
+        crawler_cfg = omega_cfg.get("wolken_crawler", {})
+        crawler.api_endpoint = crawler_cfg.get("api_endpoint", "")
+        crawler.domain = crawler_cfg.get("domain", "")
+        crawler.client_id = crawler_cfg.get("client_id", "")
+        crawler.service_account = crawler_cfg.get("service_account", "")
+        crawler.auth_code = crawler_cfg.get("auth_code", "")
+        crawler.refresh_token_value = crawler_cfg.get("refresh_token", "")
+        crawler.batch_size = crawler_cfg.get("batch_size", 100)
+        crawler.kb_source_id = crawler_cfg.get("kb_source_id", None)
+        crawler.content_fields = list(crawler_cfg.get("content_fields", []))
+
+        crawler.access_token = "test-access-token"
+        crawler.token_expires_at = 9999999999
+        crawler.session = MagicMock()
+
+    return crawler
+
+
+class TestBuildArticleContent(unittest.TestCase):
+
+    def test_extracts_configured_fields(self):
+        crawler = _make_crawler()
+        details = {
+            "articleOtherInfo": {
+                "introduction": "<p>Intro text</p>",
+                "cause": "Root cause here",
+                "resolution": "<b>Fix it</b>",
+                "environment": "Should be ignored",
+            }
+        }
+        sections = crawler._build_article_content(details)
+        self.assertEqual(len(sections), 3)
+        self.assertEqual(sections[0], ("Introduction", "Intro text"))
+        self.assertEqual(sections[1], ("Cause", "Root cause here"))
+        self.assertEqual(sections[2], ("Resolution", "Fix it"))
+
+    def test_fallback_to_description(self):
+        crawler = _make_crawler()
+        details = {
+            "articleOtherInfo": {},
+            "description": "Fallback description",
+        }
+        sections = crawler._build_article_content(details)
+        self.assertEqual(len(sections), 1)
+        self.assertEqual(sections[0], ("Description", "Fallback description"))
+
+    def test_empty_article(self):
+        crawler = _make_crawler()
+        details = {"articleOtherInfo": {}}
+        sections = crawler._build_article_content(details)
+        self.assertEqual(sections, [])
+
+    def test_none_fields_handled(self):
+        crawler = _make_crawler()
+        details = {
+            "articleOtherInfo": {
+                "introduction": None,
+                "cause": "",
+                "resolution": "Fix",
+            }
+        }
+        sections = crawler._build_article_content(details)
+        self.assertEqual(len(sections), 1)
+        self.assertEqual(sections[0], ("Resolution", "Fix"))
+
+
+class TestApiHeaders(unittest.TestCase):
+
+    def test_returns_correct_headers(self):
+        crawler = _make_crawler()
+        headers = crawler._api_headers()
+        self.assertEqual(headers["clientId"], "test-client")
+        self.assertEqual(headers["domain"], "testdomain")
+        self.assertEqual(headers["serviceAccount"], "svc@test.com")
+        self.assertEqual(headers["Authorization"], "Bearer test-access-token")
+
+    def test_refreshes_token_when_expired(self):
+        crawler = _make_crawler()
+        crawler.access_token = None
+        crawler.token_expires_at = 0
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "new-token",
+            "expires_in": 3600,
+        }
+        mock_response.raise_for_status = MagicMock()
+        crawler.session.post.return_value = mock_response
+
+        headers = crawler._api_headers()
+        self.assertEqual(headers["Authorization"], "Bearer new-token")
+        crawler.session.post.assert_called_once()
+
+
+class TestCrawlFlow(unittest.TestCase):
+
+    def test_crawl_indexes_articles(self):
+        crawler = _make_crawler()
+        crawler.indexer.index_segments = MagicMock(return_value=True)
+
+        # Mock _get to return categories, then articles, then details
+        call_count = [0]
+        def mock_get(path, params=None):
+            call_count[0] += 1
+            if "categories" in path:
+                return {"data": [{"catId": 1, "catName": "General"}]}
+            elif "/api/kb/articles/1/" in path:
+                return {"data": [
+                    {"articleId": 101, "articleTitle": "Test Article"},
+                ]}
+            elif "/api/kb/articles/101" in path:
+                return {"data": {
+                    "articleTitle": "Test Article",
+                    "articleOtherInfo": {
+                        "introduction": "Intro text",
+                        "cause": "Some cause",
+                        "resolution": "Fix it",
+                    },
+                    "createdTime": "2024-01-01",
+                    "updatedTime": "2024-01-02",
+                    "statusId": 2,
+                }}
+            return {"data": []}
+
+        crawler._get = mock_get
+        crawler.crawl()
+
+        crawler.indexer.index_segments.assert_called_once()
+        call_args = crawler.indexer.index_segments.call_args
+        self.assertEqual(call_args.kwargs["doc_id"], "wolken-kb-101")
+        self.assertEqual(call_args.kwargs["doc_title"], "Test Article")
+        self.assertEqual(len(call_args.kwargs["texts"]), 3)
+
+    def test_crawl_skips_indexed_ids(self):
+        crawler = _make_crawler()
+        crawler.tracker = MagicMock()
+        crawler.tracker.get_indexed_ids.return_value = {"wolken-kb-101"}
+        crawler.indexer.index_segments = MagicMock(return_value=True)
+
+        def mock_get(path, params=None):
+            if "categories" in path:
+                return {"data": [{"catId": 1, "catName": "General"}]}
+            elif "/api/kb/articles/1/" in path:
+                return {"data": [{"articleId": 101, "articleTitle": "Already Indexed"}]}
+            return {"data": []}
+
+        crawler._get = mock_get
+        crawler.crawl()
+
+        crawler.indexer.index_segments.assert_not_called()
+
+    def test_crawl_handles_empty_categories(self):
+        crawler = _make_crawler()
+        crawler.indexer.index_segments = MagicMock()
+
+        crawler._get = lambda path, params=None: {"data": []}
+        crawler.crawl()
+
+        crawler.indexer.index_segments.assert_not_called()
+
+
+class TestSecretsMapping(unittest.TestCase):
+
+    def test_wolken_prefix_maps_to_crawler_config(self):
+        """Verify WOLKEN_ prefixed secrets map to wolken_crawler config."""
+        from omegaconf import OmegaConf, DictConfig
+        from ingest import update_environment
+
+        cfg = OmegaConf.create({
+            "vectara": {},
+            "wolken_crawler": {},
+        })
+
+        env_dict = {
+            "WOLKEN_API_ENDPOINT": "https://api-test.wolkenservicedesk.com",
+            "WOLKEN_DOMAIN": "testdomain",
+            "WOLKEN_CLIENT_ID": "my-client",
+        }
+
+        update_environment(cfg, "test", env_dict)
+
+        self.assertEqual(cfg.wolken_crawler.api_endpoint, "https://api-test.wolkenservicedesk.com")
+        self.assertEqual(cfg.wolken_crawler.domain, "testdomain")
+        self.assertEqual(cfg.wolken_crawler.client_id, "my-client")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wolken_crawler.py
+++ b/tests/test_wolken_crawler.py
@@ -1,17 +1,21 @@
 import sys
+import importlib.machinery
 import unittest
 from unittest.mock import MagicMock, patch
 
-# Mock heavy dependencies before importing the crawler
-for mod in [
-    "cairosvg", "whisper", "pdf2image",
-    "playwright", "playwright.sync_api",
-    "core.summary", "core.indexer", "core.web_content_extractor",
-]:
-    if mod not in sys.modules:
-        sys.modules[mod] = MagicMock()
+# Mock only third-party deps that may be missing in the test env. Do NOT inject
+# MagicMocks for `core.*` modules — that pollutes sys.modules and makes the rest
+# of the suite order-dependent (other tests would get the mock instead of the
+# real class). `nbconvert` calls `importlib.util.find_spec("playwright")` at
+# import time, so the playwright mock needs a real ModuleSpec.
+for mod in ["cairosvg", "whisper", "pdf2image"]:
+    sys.modules.setdefault(mod, MagicMock())
+_playwright_mock = MagicMock()
+_playwright_mock.__spec__ = importlib.machinery.ModuleSpec("playwright", None)
+sys.modules.setdefault("playwright", _playwright_mock)
+sys.modules.setdefault("playwright.sync_api", MagicMock())
 
-from crawlers.wolken_crawler import WolkenCrawler, clean_html
+from crawlers.wolken_crawler import WolkenCrawler, clean_html, _str_or_empty
 
 
 class TestCleanHtml(unittest.TestCase):
@@ -155,6 +159,81 @@ class TestApiHeaders(unittest.TestCase):
         headers = crawler._api_headers()
         self.assertEqual(headers["Authorization"], "Bearer new-token")
         crawler.session.post.assert_called_once()
+
+    def test_short_lived_token_does_not_expire_immediately(self):
+        """Regression: if expires_in < safety margin, the clamp must keep the token usable."""
+        crawler = _make_crawler()
+        crawler.access_token = None
+        crawler.token_expires_at = 0
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "short-token",
+            "expires_in": 60,  # less than the 120s safety margin
+        }
+        mock_response.raise_for_status = MagicMock()
+        crawler.session.post.return_value = mock_response
+
+        import time as _time
+        before = _time.time()
+        crawler._ensure_token()
+        # token_expires_at must be in the future, otherwise we'd refresh on every call
+        self.assertGreater(crawler.token_expires_at, before)
+
+
+class TestStrOrEmpty(unittest.TestCase):
+
+    def test_none_becomes_empty(self):
+        self.assertEqual(_str_or_empty(None), "")
+
+    def test_int_stringified(self):
+        self.assertEqual(_str_or_empty(42), "42")
+
+    def test_empty_string_passthrough(self):
+        self.assertEqual(_str_or_empty(""), "")
+
+    def test_zero_stringified(self):
+        # zero is not None — must keep "0", not collapse to ""
+        self.assertEqual(_str_or_empty(0), "0")
+
+
+class TestMetadataNoneHandling(unittest.TestCase):
+    """Regression: dict.get returns None when key exists with None value, not the default."""
+
+    def test_null_status_id_does_not_become_string_none(self):
+        crawler = _make_crawler()
+        crawler.indexer.index_segments = MagicMock(return_value=True)
+
+        def mock_get(path, params=None):
+            if "categories" in path:
+                return {"data": [{"catId": 1, "catName": "General"}]}
+            elif "/api/kb/articles/1/" in path:
+                return {"data": [{"articleId": 101, "articleTitle": "T"}]}
+            elif "/api/kb/articles/101" in path:
+                return {"data": {
+                    "articleTitle": "T",
+                    "articleOtherInfo": {
+                        "introduction": "Some intro",
+                        "validationStatusId": None,
+                        "publishedDate": None,
+                    },
+                    "createdTime": None,
+                    "updatedTime": None,
+                    "statusId": None,
+                }}
+            return {"data": []}
+
+        crawler._get = mock_get
+        crawler.crawl()
+
+        metadata = crawler.indexer.index_segments.call_args.kwargs["doc_metadata"]
+        self.assertEqual(metadata["status_id"], "")
+        self.assertEqual(metadata["validation_status_id"], "")
+        self.assertEqual(metadata["created_time"], "")
+        self.assertEqual(metadata["updated_time"], "")
+        self.assertEqual(metadata["published_date"], "")
+        # Sanity: nothing should be the literal string "None"
+        self.assertNotIn("None", metadata.values())
 
 
 class TestCrawlFlow(unittest.TestCase):


### PR DESCRIPTION
## Summary
- New crawler for indexing Knowledge Base articles from Wolken ServiceDesk using the [public KB REST API](https://developer-beta.wolkensoftware.com/kb/docs.html)
- Uses standard REST endpoints: categories → articles → article details → index to Vectara
- Configurable content field extraction (introduction, cause, environment, resolution, additionalInfo)
- Supports resume via `reindex` flag and crawl tracking

## Files
- `crawlers/wolken_crawler.py` — Crawler implementation (308 lines)
- `config/wolken-kb.yaml` — Sample configuration
- `docs/wolken-kb-setup.md` — Setup documentation
- `tests/test_wolken_crawler.py` — 15 unit tests
- `ingest.py` — WOLKEN_ secrets prefix mapping
- `README.md` — Feature list and secrets docs

## Test plan
- [x] 15 unit tests passing (HTML cleaning, content extraction, auth, crawl flow, secrets mapping)
- [ ] Test with a live Wolken instance
- [ ] Test resume (reindex: false) after interrupted crawl
- [ ] Test reindex: true starts fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)