### PR TITLE
gdrive: make displayName filter opt-in and add per-stage drop counters

### DIFF
--- a/crawlers/CRAWLERS.md
+++ b/crawlers/CRAWLERS.md
@@ -634,7 +634,9 @@ HUBSPOT_API_KEY = "your-private-app-key"
 
     # Crawl-time filters
     days_back: 7
-    permission_display_filter: ['Vectara', 'all']
+    # Optional crawl-time displayName gate (default: unset, i.e. no filter).
+    # When set, files are kept only if a permission's displayName matches.
+    # permission_display_filter: ['Vectara', 'all']
 
     # Optional: restrict the crawl to a folder subtree
     # root_folder: https://drive.google.com/drive/folders/<folder_id>
@@ -661,7 +663,7 @@ The gdrive crawler indexes content from Google Drive with support for two authen
 - `auth_type`: `service_account` (default) or `oauth`. See "Authentication Methods" below.
 - `credentials_file`: path to the credentials JSON file. The exact contents depend on `auth_type` (service-account JSON vs. OAuth token JSON).
 - `days_back`: include only files modified within the last N days. **Default: 7.**
-- `permission_display_filter`: list of permission `displayName` values to include. A file is indexed only if at least one of its Drive permissions has a matching `displayName` (a typical pattern is your company name, e.g. `Vectara`, plus `all` to admit files shared with `anyone`/the whole organization, since those grants are surfaced with `displayName: "all"`). Set to `null` or `[]` to disable this crawl-time gate and rely solely on ABAC metadata + query-time filters. **Default: `['Vectara', 'all']`.** The legacy key `permissions` is still honored but deprecated — rename it to `permission_display_filter`.
+- `permission_display_filter`: optional list of permission `displayName` values to include. When set, a file is indexed only if at least one of its Drive permissions has a matching `displayName` (a typical pattern would be your company name plus `all` to admit files shared with `anyone`/the whole organization, since those grants are surfaced with `displayName: "all"`). **Default: unset (no filter)** — every file the delegated user can read flows through; use ABAC metadata for access control. Set to `null` or `[]` explicitly to disable. The legacy key `permissions` is still honored but deprecated — rename it to `permission_display_filter`.
 - `root_folder` (optional): restrict the crawl to a single folder and all of its descendants. Accepts either a Drive folder URL (e.g. `https://drive.google.com/drive/folders/<id>`) or the bare folder id. When unset, the crawler sweeps `root`, `sharedWithMe`, and files owned/shared with each delegated user. `days_back` still applies to leaf files; subfolders are always traversed so old folders containing recent files are not missed. Shortcuts inside the subtree are not followed, so the crawl stays strictly within the chosen folder.
 - `ray_workers`: `0` to disable Ray (default), `>0` to parallelize across `delegated_users` with that many Ray workers, `-1` to use all cores. Only meaningful for service-account mode with multiple users.
 
@@ -708,7 +710,7 @@ gdrive_crawler:
   auth_type: oauth
   credentials_file: credentials.json
   days_back: 7
-  permission_display_filter: ['Vectara', 'all']
+  # permission_display_filter: ['<your company>', 'all']   # opt-in; default is no filter
 ```
 
 **Attribute-Based Access Control (ABAC):**
@@ -737,6 +739,18 @@ When `abac.enabled: true`, every indexed document is tagged with filterable ACL 
 - Both authentication modes use the same `credentials_file` field, but the file's contents differ.
 - The OAuth token auto-refreshes and is rewritten back to `credentials_file` when it expires.
 - Audio, video, archives, executables, and source-code-style text files are skipped by mime type. Standalone images are skipped unless `doc_processing.summarize_images` is enabled.
+
+**Filter Pipeline:**
+
+Each file passes through several gates between Drive and the indexer. A drop at any stage is logged at INFO with the file name, id, mime type, and reason; a per-user summary line of the form `gdrive filter summary for user=<u> :: listed=N display_name_dropped=N cache_skipped=N mime_dropped=N unsupported_ext_dropped=N download_failed=N index_error=N indexed=N` is emitted when the user is done. The stages, in order:
+
+1. **Drive API query** — server-side `trashed=false AND modifiedTime > now - days_back`. Files outside the window are never returned by Drive and so are not counted.
+2. **`permission_display_filter`** — optional. When set, keeps a file only if some permission's `displayName` matches the allowlist. **Default: unset (no filter).** Use this only for legacy gating; prefer ABAC metadata + query-time filters for new deployments.
+3. **Shared cache** — when multiple `delegated_users` are crawled, the second-seen user skips files already indexed by the first.
+4. **MIME prefix blocklist** — `audio*`, `video*`, folders, `application/x-adobe-indesign`, `application/zip`, `application/x-rar-compressed`, `application/x-7z-compressed`, `application/x-executable`, `text/php|javascript|css|xml|x-sql|x-python-script`, and `image*` unless `doc_processing.summarize_images: true`.
+5. **Extension allowlist (post-download)** — file is rejected unless it's a dataframe (`.csv/.xls/.xlsx`) or extension is in `{.doc, .docx, .ppt, .pptx, .pdf, .odt, .txt, .html, .md, .rtf, .epub, .lxml}` (plus image extensions when `summarize_images` is on).
+6. **Download/export** — files whose Drive download or Workspace export fails (e.g. `exportSizeLimitExceeded` with no PDF fallback) are counted as `download_failed`.
+7. **Indexing** — `indexer.index_file` returning `False` or raising is counted as `index_error`; success is counted as `indexed`.
 
 
 ### Folder crawler

--- a/crawlers/CRAWLERS.md
+++ b/crawlers/CRAWLERS.md
@@ -748,7 +748,7 @@ Each file passes through several gates between Drive and the indexer. A drop at 
 2. **`permission_display_filter`** — optional. When set, keeps a file only if some permission's `displayName` matches the allowlist. **Default: unset (no filter).** Use this only for legacy gating; prefer ABAC metadata + query-time filters for new deployments.
 3. **Shared cache** — when multiple `delegated_users` are crawled, the second-seen user skips files already indexed by the first.
 4. **MIME prefix blocklist** — `audio*`, `video*`, folders, `application/x-adobe-indesign`, `application/zip`, `application/x-rar-compressed`, `application/x-7z-compressed`, `application/x-executable`, `text/php|javascript|css|xml|x-sql|x-python-script`, and `image*` unless `doc_processing.summarize_images: true`.
-5. **Extension allowlist (post-download)** — file is rejected unless it's a dataframe (`.csv/.xls/.xlsx`) or extension is in `{.doc, .docx, .ppt, .pptx, .pdf, .odt, .txt, .html, .md, .rtf, .epub, .lxml}` (plus image extensions when `summarize_images` is on).
+5. **Extension allowlist (post-download)** — file is rejected unless it's a dataframe (`.csv`, `.tsv`, `.psv`, `.pipe`, `.xls`, `.xlsx` — see `supported_by_dataframe_parser` in `core/dataframe_parser.py`) or extension is in `{.doc, .docx, .ppt, .pptx, .pdf, .odt, .txt, .html, .md, .rtf, .epub, .lxml}` (plus image extensions when `summarize_images` is on).
 6. **Download/export** — files whose Drive download or Workspace export fails (e.g. `exportSizeLimitExceeded` with no PDF fallback) are counted as `download_failed`.
 7. **Indexing** — `indexer.index_file` returning `False` or raising is counted as `index_error`; success is counted as `indexed`.
 

--- a/crawlers/gdrive_crawler.py
+++ b/crawlers/gdrive_crawler.py
@@ -765,7 +765,7 @@ class UserWorker(object):
 
         try:
             if is_dataframe:
-                process_dataframe_file(
+                ok = process_dataframe_file(
                     file_path=local_file_path,
                     metadata=file_metadata,
                     doc_id=file_id,
@@ -773,7 +773,10 @@ class UserWorker(object):
                     df_config=self.cfg.get('dataframe_processing', {}),
                     source_name='gdrive',
                 )
-                self._record_indexed(file)
+                if ok:
+                    self._record_indexed(file)
+                else:
+                    self._record_drop('index_error', file, "process_dataframe_file returned False")
             else:
                 ok = self.indexer.index_file(filename=local_file_path, uri=url, metadata=file_metadata)
                 if ok:

--- a/crawlers/gdrive_crawler.py
+++ b/crawlers/gdrive_crawler.py
@@ -45,10 +45,10 @@ _PERM_FIELDS = (
     'permissions(id,type,role,emailAddress,domain,deleted,displayName,permissionDetails)'
 )
 
-# Legacy crawl-time displayName gate, preserved for backward compatibility.
-# Files are indexed only if one of their permissions has a matching displayName.
-# Set the config key to null/[] to disable and rely solely on ABAC metadata.
-DEFAULT_PERMISSION_DISPLAY_FILTER = ['Vectara', 'all']
+# Legacy crawl-time displayName gate, opt-in. When configured, files are
+# indexed only if one of their permissions has a matching displayName. The
+# default is unset (None) so every file the delegated user can read flows
+# through; tenants that want ACL-style gating should configure ABAC instead.
 
 # Values for the acl_source metadata field. Persisted in the corpus, so stable.
 ACL_SOURCE_SHARED_DRIVE = 'shared_drive'
@@ -250,6 +250,22 @@ def extract_acl_metadata(
     }
 
 
+# Buckets reported in the per-user filter summary. Order is the order files
+# traverse the pipeline; keeping it stable makes log diffs across runs easy
+# to compare. `listed` is files returned by Drive (post-server-query); each
+# subsequent bucket is a drop reason; `indexed` is the terminal success.
+FILTER_STAGES = (
+    'listed',
+    'display_name_dropped',
+    'cache_skipped',
+    'mime_dropped',
+    'unsupported_ext_dropped',
+    'download_failed',
+    'index_error',
+    'indexed',
+)
+
+
 class UserWorker(object):
     def __init__(
             self,
@@ -293,6 +309,13 @@ class UserWorker(object):
         self._folder_acl_cache: Dict[str, Tuple[List[Dict[str, Any]], List[str]]] = {}
         self._label_defs: Optional[Dict[str, Dict[str, Any]]] = None
 
+        # Per-user filter pipeline counters. Reset at the start of process();
+        # incremented by _record_drop()/_record_indexed() as files traverse the
+        # gates documented in CRAWLERS.md. A summary is logged when process()
+        # returns so operators can see how many files were dropped at each
+        # stage (most opaque drop today is the display-name gate).
+        self._stats: Dict[str, int] = {k: 0 for k in FILTER_STAGES}
+
         # Standalone images are routed through the indexer's ImageFileParser,
         # but only when a vision-capable summarizer is enabled. Gating on this
         # flag avoids downloading images we'd have to drop at index time.
@@ -320,6 +343,29 @@ class UserWorker(object):
         allow = set(self.permission_display_filter)
         return any(p.get('displayName') in allow for p in permissions)
 
+    def _record_drop(self, bucket: str, file_obj: Dict[str, Any], reason: str) -> None:
+        """Increment a drop counter and emit an INFO line so the operator can
+        see exactly which file was filtered and why. Cheap enough to do for
+        every drop — Drive crawls are network-bound, not log-bound.
+        """
+        if bucket not in self._stats:
+            raise KeyError(f"unknown filter bucket: {bucket}")
+        self._stats[bucket] += 1
+        logger.info(
+            f"gdrive filter drop [{bucket}] file='{file_obj.get('name', '?')}' "
+            f"id={file_obj.get('id', '?')} mime={file_obj.get('mimeType', '?')} :: {reason}"
+        )
+
+    def _record_indexed(self, file_obj: Dict[str, Any]) -> None:
+        self._stats['indexed'] += 1
+        logger.info(
+            f"gdrive indexed file='{file_obj.get('name', '?')}' id={file_obj.get('id', '?')}"
+        )
+
+    def _log_filter_summary(self, user: str) -> None:
+        parts = ' '.join(f"{k}={self._stats[k]}" for k in FILTER_STAGES)
+        logger.info(f"gdrive filter summary for user={user} :: {parts}")
+
     def list_files(self, service: Resource, date_threshold: Optional[str] = None) -> List[dict]:
         results = []
         page_token = None
@@ -345,8 +391,15 @@ class UserWorker(object):
                 files = response.get('files', [])
 
                 for file in files:
+                    self._stats['listed'] += 1
                     if self._passes_display_filter(file.get('permissions', [])):
                         results.append(file)
+                    else:
+                        self._record_drop(
+                            'display_name_dropped',
+                            file,
+                            f"no permission displayName matched {self.permission_display_filter}",
+                        )
                 page_token = response.get('nextPageToken', None)
                 if not page_token:
                     break
@@ -409,8 +462,15 @@ class UserWorker(object):
                             elif mime == SHORTCUT_MIME:
                                 continue
                             else:
+                                self._stats['listed'] += 1
                                 if self._passes_display_filter(f.get('permissions', [])):
                                     results.append(f)
+                                else:
+                                    self._record_drop(
+                                        'display_name_dropped',
+                                        f,
+                                        f"no permission displayName matched {self.permission_display_filter}",
+                                    )
 
                         page_token = response.get('nextPageToken')
                         if not page_token:
@@ -647,6 +707,7 @@ class UserWorker(object):
             local_file_path = self.save_local_file(file_id, name)
 
         if not local_file_path:
+            self._record_drop('download_failed', file, "download_or_export_file returned no bytes")
             return
 
         # Route by type: dataframes go through DataframeParser; images use the
@@ -658,6 +719,11 @@ class UserWorker(object):
 
         is_dataframe = supported_by_dataframe_parser(local_file_path)
         if not is_dataframe and not any(local_file_path.endswith(ext) for ext in supported_extensions):
+            self._record_drop(
+                'unsupported_ext_dropped',
+                file,
+                f"local path {local_file_path!r} not in supported extensions {supported_extensions}",
+            )
             safe_remove_file(local_file_path)
             return
 
@@ -707,15 +773,26 @@ class UserWorker(object):
                     df_config=self.cfg.get('dataframe_processing', {}),
                     source_name='gdrive',
                 )
+                self._record_indexed(file)
             else:
-                self.indexer.index_file(filename=local_file_path, uri=url, metadata=file_metadata)
+                ok = self.indexer.index_file(filename=local_file_path, uri=url, metadata=file_metadata)
+                if ok:
+                    self._record_indexed(file)
+                else:
+                    self._record_drop('index_error', file, "indexer.index_file returned False")
         except Exception as e:
             logger.warning(f"Error {e} indexing document for file {name}, file_id {file_id}")
+            self._record_drop('index_error', file, f"exception: {e}")
 
         safe_remove_file(local_file_path)
 
     def process(self, user: str) -> None:
         logger.info(f"Processing files for user: {user}")
+
+        # Reset per-user filter counters so each call to process() yields a
+        # clean summary line. With Ray, this matters because the same actor
+        # services multiple users sequentially.
+        self._stats = {k: 0 for k in FILTER_STAGES}
 
         # Determine authentication method based on configuration
         auth_type = self.cfg.gdrive_crawler.get("auth_type", "service_account")
@@ -749,12 +826,20 @@ class UserWorker(object):
             files = self._list_subtree(self.service, self._root_folder_id, date_threshold_str)
         else:
             files = self.list_files(self.service, date_threshold=date_threshold_str)
-        if self.use_ray:
-            files = [file for file in files if not ray.get(self.shared_cache.contains.remote(file['id']))]
-        else:
-            files = [file for file in files if not self.shared_cache.contains(file['id'])]
 
-        # remove mime types we don't want to crawl
+        # Cache gate: drop files already crawled by another user/worker.
+        def _already_seen(file_id: str) -> bool:
+            return (ray.get(self.shared_cache.contains.remote(file_id))
+                    if self.use_ray else self.shared_cache.contains(file_id))
+        kept: List[dict] = []
+        for f in files:
+            if _already_seen(f['id']):
+                self._record_drop('cache_skipped', f, "already crawled in this run")
+            else:
+                kept.append(f)
+        files = kept
+
+        # MIME prefix gate: drop file types the parsers won't handle.
         mime_prefix_to_remove = [
             'audio', 'video',
             'application/vnd.google-apps.folder', 'application/x-adobe-indesign',
@@ -764,10 +849,17 @@ class UserWorker(object):
         ]
         if not self._summarize_images:
             mime_prefix_to_remove.append('image')
-        files = [file for file in files if not any(file['mimeType'].startswith(mime_type) for mime_type in mime_prefix_to_remove)]
+        kept = []
+        for f in files:
+            matched = next((p for p in mime_prefix_to_remove if f['mimeType'].startswith(p)), None)
+            if matched is not None:
+                self._record_drop('mime_dropped', f, f"mimeType starts with blocked prefix '{matched}'")
+            else:
+                kept.append(f)
+        files = kept
 
         if self.crawler.verbose:
-            logging.info(f"identified {len(files)} files for user {user}")
+            logger.info(f"identified {len(files)} files for user {user} (post mime/cache gates)")
 
         # get access token
         try:
@@ -775,6 +867,7 @@ class UserWorker(object):
             self.access_token = self.creds.token
         except Exception as e:
             logger.warning(f"Error refreshing token: {e} for user {user}")
+            self._log_filter_summary(user)
             return
 
         for file in files:
@@ -785,6 +878,8 @@ class UserWorker(object):
                 if not self.shared_cache.contains(file['id']):
                     self.shared_cache.add(file['id'])
             self.crawl_file(file)
+
+        self._log_filter_summary(user)
 
 class GdriveCrawler(Crawler):
 
@@ -804,8 +899,8 @@ class GdriveCrawler(Crawler):
     def _resolve_permission_display_filter(self) -> Optional[List[str]]:
         """Read the crawl-time displayName gate, honoring the deprecated 'permissions' key.
 
-        Returns None when the gate is disabled (config null or empty list), else
-        the list of allowed displayName strings.
+        Returns None when the gate is disabled (config null, empty list, or
+        unset — the default), else the list of allowed displayName strings.
         """
         gdrive = self.cfg.gdrive_crawler
         if 'permission_display_filter' in gdrive:
@@ -818,7 +913,7 @@ class GdriveCrawler(Crawler):
             )
             value = gdrive.get('permissions')
         else:
-            value = list(DEFAULT_PERMISSION_DISPLAY_FILTER)
+            return None
 
         if value is None:
             return None

--- a/crawlers/gdrive_crawler.py
+++ b/crawlers/gdrive_crawler.py
@@ -356,15 +356,49 @@ class UserWorker(object):
             f"id={file_obj.get('id', '?')} mime={file_obj.get('mimeType', '?')} :: {reason}"
         )
 
-    def _record_indexed(self, file_obj: Dict[str, Any]) -> None:
+    def _record_indexed(
+        self,
+        file_obj: Dict[str, Any],
+        file_metadata: Optional[Dict[str, Any]] = None,
+        parent_permissions: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
         self._stats['indexed'] += 1
         # Per-file success line is gated behind verbose: on large corpora the
         # summary counter is the signal operators want, and one INFO per
         # indexed file dominates log volume on healthy runs.
-        if self.crawler.verbose:
-            logger.info(
-                f"gdrive indexed file='{file_obj.get('name', '?')}' id={file_obj.get('id', '?')}"
+        if not self.crawler.verbose:
+            return
+
+        line = (
+            f"gdrive indexed file='{file_obj.get('name', '?')}' "
+            f"id={file_obj.get('id', '?')}"
+        )
+        # Raw permissions are logged independent of ABAC so operators can debug
+        # acl_* derivation (or just inspect what Drive returned) even with ABAC
+        # off. parent_permissions is appended only when non-empty to keep the
+        # line tight for Shared Drive files and non-resolve_inherited runs.
+        line += f" permissions={file_obj.get('permissions', [])!r}"
+        if parent_permissions:
+            line += f" parent_permissions={parent_permissions!r}"
+        # When ABAC is on, append the resolved acl_* values so operators can
+        # confirm per-file what the indexer actually shipped to the corpus
+        # (inheritance source, public/org-wide flags, group/domain grants,
+        # labels). Order is stable for grep-ability.
+        if self._abac_enabled and file_metadata is not None:
+            acl_keys = (
+                'acl_source',
+                'acl_is_public',
+                'acl_is_org_wide',
+                'acl_owners',
+                'acl_readers',
+                'acl_groups',
+                'acl_domains',
+                'acl_labels',
             )
+            line += ' ' + ' '.join(
+                f"{k}={file_metadata[k]!r}" for k in acl_keys if k in file_metadata
+            )
+        logger.info(line)
 
     def _log_filter_summary(self, user: str) -> None:
         parts = ' '.join(f"{k}={self._stats[k]}" for k in FILTER_STAGES)
@@ -758,6 +792,7 @@ class UserWorker(object):
             'source': 'gdrive'
         }
 
+        parent_perms: Optional[List[Dict[str, Any]]] = None
         if self._abac_enabled:
             parent_perms, source = self._resolve_parent_acl(file)
 
@@ -784,13 +819,13 @@ class UserWorker(object):
                     source_name='gdrive',
                 )
                 if ok:
-                    self._record_indexed(file)
+                    self._record_indexed(file, file_metadata, parent_permissions=parent_perms)
                 else:
                     self._record_drop('index_error', file, "process_dataframe_file returned False")
             else:
                 ok = self.indexer.index_file(filename=local_file_path, uri=url, metadata=file_metadata)
                 if ok:
-                    self._record_indexed(file)
+                    self._record_indexed(file, file_metadata, parent_permissions=parent_perms)
                 else:
                     self._record_drop('index_error', file, "indexer.index_file returned False")
         except Exception as e:
@@ -907,6 +942,11 @@ class GdriveCrawler(Crawler):
         if auth_type == "oauth":
             self.delegated_users = ["oauth_user"]  # Dummy user for OAuth mode
         else:
+            if "delegated_users" not in cfg.gdrive_crawler:
+                raise ValueError(
+                    "gdrive_crawler.delegated_users is required for auth_type='service_account'. "
+                    "Provide a list of user emails to impersonate, or set auth_type: oauth."
+                )
             self.delegated_users = cfg.gdrive_crawler.delegated_users
 
     def _resolve_permission_display_filter(self) -> Optional[List[str]]:

--- a/crawlers/gdrive_crawler.py
+++ b/crawlers/gdrive_crawler.py
@@ -358,9 +358,13 @@ class UserWorker(object):
 
     def _record_indexed(self, file_obj: Dict[str, Any]) -> None:
         self._stats['indexed'] += 1
-        logger.info(
-            f"gdrive indexed file='{file_obj.get('name', '?')}' id={file_obj.get('id', '?')}"
-        )
+        # Per-file success line is gated behind verbose: on large corpora the
+        # summary counter is the signal operators want, and one INFO per
+        # indexed file dominates log volume on healthy runs.
+        if self.crawler.verbose:
+            logger.info(
+                f"gdrive indexed file='{file_obj.get('name', '?')}' id={file_obj.get('id', '?')}"
+            )
 
     def _log_filter_summary(self, user: str) -> None:
         parts = ' '.join(f"{k}={self._stats[k]}" for k in FILTER_STAGES)
@@ -677,19 +681,25 @@ class UserWorker(object):
 
             return None
 
-    def save_local_file(self, file_id: str, name: str, mime_type: Optional[str] = None) -> Optional[str]:
+    def save_local_file(
+        self, file_id: str, name: str, mime_type: Optional[str] = None
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Download a Drive file to /tmp. Returns (local_path, error_reason);
+        on success error_reason is None, on failure local_path is None and
+        error_reason names the failing stage so callers can surface it."""
         path, extension = os.path.splitext(name)
         sanitized_name = f"{slugify(path)}{extension}"
         file_path = os.path.join("/tmp", sanitized_name)
         try:
             byte_stream = self.download_or_export_file(file_id, mime_type)
-            if byte_stream:
-                with open(file_path, 'wb') as f:
-                    f.write(byte_stream.read())
-                return file_path
+            if byte_stream is None:
+                return None, "download_or_export_file returned no bytes"
+            with open(file_path, 'wb') as f:
+                f.write(byte_stream.read())
+            return file_path, None
         except Exception as e:
             logger.warning(f"Error saving local file: {e}")
-        return None
+            return None, f"local file write failed: {e}"
 
     def crawl_file(self, file: dict) -> None:
         file_id = file['id']
@@ -698,16 +708,16 @@ class UserWorker(object):
 
         url = get_gdrive_url(file_id, mime_type)
         if mime_type == 'application/vnd.google-apps.document':
-            local_file_path = self.save_local_file(file_id, name + '.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document')
+            local_file_path, download_error = self.save_local_file(file_id, name + '.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document')
         elif mime_type == 'application/vnd.google-apps.presentation':
-            local_file_path = self.save_local_file(file_id, name + '.pptx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation')
+            local_file_path, download_error = self.save_local_file(file_id, name + '.pptx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation')
         elif mime_type == 'application/vnd.google-apps.spreadsheet':
-            local_file_path = self.save_local_file(file_id, name + '.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+            local_file_path, download_error = self.save_local_file(file_id, name + '.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
         else:
-            local_file_path = self.save_local_file(file_id, name)
+            local_file_path, download_error = self.save_local_file(file_id, name)
 
         if not local_file_path:
-            self._record_drop('download_failed', file, "download_or_export_file returned no bytes")
+            self._record_drop('download_failed', file, download_error or "unknown save_local_file failure")
             return
 
         # Route by type: dataframes go through DataframeParser; images use the

--- a/tests/test_gdrive_crawler.py
+++ b/tests/test_gdrive_crawler.py
@@ -11,6 +11,7 @@ from googleapiclient.errors import HttpError
 from crawlers.gdrive_crawler import (
     DRIVE_LABELS_SCOPE,
     DRIVE_READONLY_SCOPE,
+    FILTER_STAGES,
     GdriveCrawler,
     UserWorker,
     build_scopes,
@@ -161,6 +162,7 @@ def _make_worker(abac=None, permission_display_filter=None, root_folder_id=None)
     worker._root_folder_id = root_folder_id
     worker._folder_acl_cache = {}
     worker._label_defs = None
+    worker._stats = {k: 0 for k in FILTER_STAGES}
     return worker
 
 
@@ -204,6 +206,13 @@ class TestResolvePermissionDisplayFilter(unittest.TestCase):
 
     def test_explicit_null_disables_filter(self):
         c = self._crawler({"permission_display_filter": None})
+        self.assertIsNone(c._resolve_permission_display_filter())
+
+    def test_unset_defaults_to_no_filter(self):
+        """Pinning the default: when the config key is absent, no display-name
+        gate is applied. Earlier versions defaulted to ['Vectara','all'], which
+        silently dropped most files for non-Vectara tenants."""
+        c = self._crawler({})
         self.assertIsNone(c._resolve_permission_display_filter())
 
 
@@ -434,6 +443,79 @@ class TestListSubtree(unittest.TestCase):
         self._wire_service(w, tree)
         files = w._list_subtree(w.service, "ROOT", "2020-01-01T00:00:00Z")
         self.assertEqual(files, [])
+
+
+class TestFilterCounters(unittest.TestCase):
+    """Each filter gate must (a) increment the right bucket and (b) leave
+    the other buckets alone. Without this, the per-user summary line silently
+    drifts from reality the moment a new gate is added."""
+
+    FOLDER_MIME = "application/vnd.google-apps.folder"
+
+    def _wire_service(self, worker, tree):
+        def fake_list(**params):
+            parent = params.get("q", "").split("'")[1]
+            children = tree.get(parent, [])
+            exec_mock = MagicMock()
+            exec_mock.execute.return_value = {"files": list(children), "nextPageToken": None}
+            return exec_mock
+
+        worker.service.files = MagicMock()
+        worker.service.files.return_value.list = MagicMock(side_effect=fake_list)
+
+    def test_listed_counts_every_file_returned_by_drive(self):
+        """listed must reflect pre-display-filter Drive output, not survivors."""
+        w = _make_worker(root_folder_id="ROOT", permission_display_filter=["Vectara"])
+        tree = {
+            "ROOT": [
+                {"id": "D1", "name": "ok.pdf", "mimeType": "application/pdf",
+                 "permissions": [{"displayName": "Vectara"}]},
+                {"id": "D2", "name": "blocked.pdf", "mimeType": "application/pdf",
+                 "permissions": [{"displayName": "Other"}]},
+                {"id": "D3", "name": "blocked2.pdf", "mimeType": "application/pdf",
+                 "permissions": [{"displayName": "Random"}]},
+            ],
+        }
+        self._wire_service(w, tree)
+        w._list_subtree(w.service, "ROOT", "2020-01-01T00:00:00Z")
+
+        self.assertEqual(w._stats['listed'], 3)
+        self.assertEqual(w._stats['display_name_dropped'], 2)
+
+    def test_record_drop_rejects_unknown_bucket(self):
+        """Typo guard: misspelled bucket names must blow up the test suite,
+        not silently increment a phantom counter."""
+        w = _make_worker()
+        with self.assertRaises(KeyError):
+            w._record_drop('typo_dropped', {'id': 'x', 'name': 'y', 'mimeType': 'z'}, 'reason')
+
+    def test_summary_logs_all_stages(self):
+        """The summary line is the operator's primary diagnostic — every
+        bucket must be present so a drop never goes unreported."""
+        w = _make_worker()
+        w._stats['listed'] = 4
+        w._stats['display_name_dropped'] = 1
+        w._stats['indexed'] = 3
+
+        import logging as _logging
+        with self.assertLogs('crawlers.gdrive_crawler', level=_logging.INFO) as cm:
+            w._log_filter_summary("user@example.com")
+
+        summary = next(line for line in cm.output if "filter summary" in line)
+        self.assertIn("user=user@example.com", summary)
+        for stage in FILTER_STAGES:
+            self.assertIn(f"{stage}=", summary)
+        self.assertIn("listed=4", summary)
+        self.assertIn("display_name_dropped=1", summary)
+        self.assertIn("indexed=3", summary)
+
+    def test_record_indexed_increments_only_indexed(self):
+        w = _make_worker()
+        w._record_indexed({'id': 'x', 'name': 'y'})
+        self.assertEqual(w._stats['indexed'], 1)
+        for stage in FILTER_STAGES:
+            if stage != 'indexed':
+                self.assertEqual(w._stats[stage], 0, f"unexpected increment of {stage}")
 
 
 # ----- crawl_file routing: images, CSV/XLSX, Google Sheets -----

--- a/tests/test_gdrive_crawler.py
+++ b/tests/test_gdrive_crawler.py
@@ -517,6 +517,30 @@ class TestFilterCounters(unittest.TestCase):
             if stage != 'indexed':
                 self.assertEqual(w._stats[stage], 0, f"unexpected increment of {stage}")
 
+    def test_dataframe_failure_records_index_error_not_indexed(self):
+        """process_dataframe_file returns False on parser-init failure, unsupported
+        files, and caught exceptions — none of which re-raise. The outer code must
+        honor that signal, otherwise the summary line over-reports indexed and
+        never increments index_error for dataframe failures."""
+        from unittest.mock import patch
+        w = _make_worker()
+        w._summarize_images = False
+        w.df_parser = MagicMock()
+        w._abac_enabled = False
+        w.crawler = MagicMock()
+        w.crawler.verbose = False
+        w.cfg.get = MagicMock(return_value={})
+
+        file = {"id": "CSV_ID", "name": "salaries.csv", "mimeType": "text/csv"}
+
+        with patch.object(w, "save_local_file", return_value="/tmp/salaries.csv"), \
+             patch("crawlers.gdrive_crawler.process_dataframe_file", return_value=False), \
+             patch("crawlers.gdrive_crawler.safe_remove_file"):
+            w.crawl_file(file)
+
+        self.assertEqual(w._stats['indexed'], 0)
+        self.assertEqual(w._stats['index_error'], 1)
+
 
 # ----- crawl_file routing: images, CSV/XLSX, Google Sheets -----
 

--- a/tests/test_gdrive_crawler.py
+++ b/tests/test_gdrive_crawler.py
@@ -517,6 +517,108 @@ class TestFilterCounters(unittest.TestCase):
             if stage != 'indexed':
                 self.assertEqual(w._stats[stage], 0, f"unexpected increment of {stage}")
 
+    def test_record_indexed_verbose_logs_acl_fields(self):
+        """When ABAC is on and verbose is true, the per-file indexed line must
+        carry every acl_* value so operators can confirm what the indexer
+        shipped to the corpus."""
+        import logging as _logging
+        w = _make_worker()
+        w._abac_enabled = True
+        w.crawler = MagicMock()
+        w.crawler.verbose = True
+        file_metadata = {
+            'acl_owners': ['a@x.com'],
+            'acl_readers': ['b@x.com', 'c@x.com'],
+            'acl_groups': ['eng@x.com'],
+            'acl_domains': ['x.com'],
+            'acl_is_public': False,
+            'acl_is_org_wide': True,
+            'acl_labels': ['Sensitivity=Confidential'],
+            'acl_source': 'shared_drive',
+        }
+
+        with self.assertLogs('crawlers.gdrive_crawler', level=_logging.INFO) as cm:
+            w._record_indexed({'id': 'x', 'name': 'y'}, file_metadata)
+
+        line = next(l for l in cm.output if 'gdrive indexed' in l)
+        self.assertIn("file='y'", line)
+        self.assertIn("id=x", line)
+        self.assertIn("acl_source='shared_drive'", line)
+        self.assertIn("acl_is_public=False", line)
+        self.assertIn("acl_is_org_wide=True", line)
+        self.assertIn("acl_owners=['a@x.com']", line)
+        self.assertIn("'b@x.com'", line)
+        self.assertIn("'c@x.com'", line)
+        self.assertIn("acl_groups=['eng@x.com']", line)
+        self.assertIn("acl_domains=['x.com']", line)
+        self.assertIn("acl_labels=['Sensitivity=Confidential']", line)
+
+    def test_record_indexed_verbose_logs_raw_permissions(self):
+        """Raw permissions[] must appear on the verbose indexed line regardless
+        of ABAC state, so operators can debug acl_* derivation (and inspect what
+        Drive actually returned) even when ABAC is off. parent_permissions
+        is appended only when non-empty."""
+        import logging as _logging
+        w = _make_worker()
+        w._abac_enabled = False
+        w.crawler = MagicMock()
+        w.crawler.verbose = True
+        perms = [
+            {'id': 'p1', 'type': 'user', 'role': 'owner', 'emailAddress': 'a@x.com'},
+            {'id': 'p2', 'type': 'domain', 'role': 'reader', 'domain': 'x.com'},
+        ]
+
+        with self.assertLogs('crawlers.gdrive_crawler', level=_logging.INFO) as cm:
+            w._record_indexed({'id': 'x', 'name': 'y', 'permissions': perms})
+
+        line = next(l for l in cm.output if 'gdrive indexed' in l)
+        self.assertIn("permissions=", line)
+        self.assertIn("'a@x.com'", line)
+        self.assertIn("'domain'", line)
+        self.assertNotIn("parent_permissions=", line)
+
+        # Non-empty parent_permissions => the parent_permissions= token appears.
+        parent = [{'id': 'pp1', 'type': 'group', 'role': 'reader', 'emailAddress': 'eng@x.com'}]
+        with self.assertLogs('crawlers.gdrive_crawler', level=_logging.INFO) as cm2:
+            w._record_indexed(
+                {'id': 'x', 'name': 'y', 'permissions': perms},
+                parent_permissions=parent,
+            )
+        line2 = next(l for l in cm2.output if 'gdrive indexed' in l)
+        self.assertIn("parent_permissions=", line2)
+        self.assertIn("'eng@x.com'", line2)
+
+    def test_record_indexed_verbose_no_acl_when_abac_disabled(self):
+        """ABAC off => keep the line compact even if file_metadata is passed.
+        Guards against accidentally bloating the log for non-ABAC corpora."""
+        import logging as _logging
+        w = _make_worker()
+        w._abac_enabled = False
+        w.crawler = MagicMock()
+        w.crawler.verbose = True
+        file_metadata = {'acl_source': 'shared_drive', 'acl_owners': ['a@x.com']}
+
+        with self.assertLogs('crawlers.gdrive_crawler', level=_logging.INFO) as cm:
+            w._record_indexed({'id': 'x', 'name': 'y'}, file_metadata)
+
+        line = next(l for l in cm.output if 'gdrive indexed' in l)
+        self.assertNotIn('acl_', line)
+
+    def test_record_indexed_not_verbose_emits_no_line(self):
+        """Verbose gate stays in force regardless of ABAC state."""
+        import logging as _logging
+        w = _make_worker()
+        w._abac_enabled = True
+        w.crawler = MagicMock()
+        w.crawler.verbose = False
+        # assertLogs requires at least one record; emit a sentinel so the
+        # context manager doesn't raise, then confirm no 'gdrive indexed' line.
+        with self.assertLogs('crawlers.gdrive_crawler', level=_logging.INFO) as cm:
+            _logging.getLogger('crawlers.gdrive_crawler').info('sentinel')
+            w._record_indexed({'id': 'x', 'name': 'y'}, {'acl_source': 'shared_drive'})
+
+        self.assertFalse(any('gdrive indexed' in l for l in cm.output))
+
     def test_dataframe_failure_records_index_error_not_indexed(self):
         """process_dataframe_file returns False on parser-init failure, unsupported
         files, and caught exceptions — none of which re-raise. The outer code must

--- a/tests/test_gdrive_crawler.py
+++ b/tests/test_gdrive_crawler.py
@@ -533,7 +533,7 @@ class TestFilterCounters(unittest.TestCase):
 
         file = {"id": "CSV_ID", "name": "salaries.csv", "mimeType": "text/csv"}
 
-        with patch.object(w, "save_local_file", return_value="/tmp/salaries.csv"), \
+        with patch.object(w, "save_local_file", return_value=("/tmp/salaries.csv", None)), \
              patch("crawlers.gdrive_crawler.process_dataframe_file", return_value=False), \
              patch("crawlers.gdrive_crawler.safe_remove_file"):
             w.crawl_file(file)
@@ -564,12 +564,12 @@ class TestCrawlFileRouting(unittest.TestCase):
     Google Sheets export, CSV/XLSX dataframe routing, standalone image admission."""
 
     def _fake_save(self, path):
-        """save_local_file replacement: records (file_id, name, mime) and returns a path."""
+        """save_local_file replacement: records (file_id, name, mime) and returns (path, None)."""
         calls = []
 
         def save(file_id, name, mime_type=None):
             calls.append((file_id, name, mime_type))
-            return path
+            return path, None
 
         return save, calls
 


### PR DESCRIPTION
## Summary
- Default `permission_display_filter` to unset (no filter) instead of `['Vectara', 'all']`, so non-Vectara tenants are not silently filtered down to nothing. ABAC remains the recommended access-control mechanism; the legacy gate is opt-in for tenants that still want it.
- Add per-user filter pipeline counters (`listed`, `display_name_dropped`, `cache_skipped`, `mime_dropped`, `unsupported_ext_dropped`, `download_failed`, `index_error`, `indexed`) with an INFO-level summary line per user, plus an INFO line on every drop with file name/id/mime and reason. This makes it obvious where files vanish in the pipeline.
- Update `CRAWLERS.md` with the new default, the filter-pipeline section, and the summary log format. Add tests covering the new default, the `listed`/`display_name_dropped` accounting in `_list_subtree`, the unknown-bucket guard, the summary content, and `_record_indexed`.

## Test plan
- [x] `pytest tests/test_gdrive_crawler.py`
- [ ] Spot-check a real gdrive crawl with `permission_display_filter` unset and confirm the per-user summary line is emitted with sensible counts
- [ ] Spot-check a crawl with `permission_display_filter: ['Vectara', 'all']` still configured (back-compat) and confirm drops show up in `display_name_dropped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)