### PR TITLE
box: don't infer deletions from incomplete folder listings

### DIFF
--- a/crawlers/box_crawler.py
+++ b/crawlers/box_crawler.py
@@ -992,10 +992,10 @@ class BoxCrawler(Crawler):
         """
         all_files: Dict[str, Dict[str, Any]] = {}
         file_ext_set = set(str(e).lower() for e in self.file_extensions) if self.file_extensions else set()
-        listing_complete = True
 
-        def _crawl(fid: str, path: str = ""):
-            nonlocal listing_complete
+        def _crawl(fid: str, path: str = "") -> bool:
+            """Return True if this folder and all reachable subfolders listed successfully."""
+            complete = True
             try:
                 folder = self.client.folder(fid).get(fields=["name", "id"])
                 current_path = f"{path}/{folder.name}" if path else folder.name
@@ -1013,13 +1013,17 @@ class BoxCrawler(Crawler):
                             "path": current_path,
                         }
                     elif item.type == "folder" and self.recursive:
-                        _crawl(str(item.id), current_path)
+                        if not _crawl(str(item.id), current_path):
+                            complete = False
             except Exception as e:
-                listing_complete = False
                 logging.error(f"Error crawling folder {fid} for incremental check: {e}")
+                return False
+            return complete
 
+        listing_complete = True
         for folder_id in folder_ids:
-            _crawl(str(folder_id))
+            if not _crawl(str(folder_id)):
+                listing_complete = False
 
         return all_files, listing_complete
 

--- a/crawlers/box_crawler.py
+++ b/crawlers/box_crawler.py
@@ -978,16 +978,24 @@ class BoxCrawler(Crawler):
             return timedelta(days=int(s[:-1]))
         return timedelta(hours=int(s))
 
-    def _get_all_box_files(self, folder_ids: List[str]) -> Dict[str, Dict[str, Any]]:
-        """Crawl Box folders and return dict of file_id -> {name, modified_at, size, path}.
+    def _get_all_box_files(self, folder_ids: List[str]) -> Tuple[Dict[str, Dict[str, Any]], bool]:
+        """Crawl Box folders and return (file map, listing_complete).
 
         Uses the authenticated Box client to traverse all configured folders.
         Respects file_extensions filter and recursive setting.
+
+        The ``listing_complete`` flag is ``False`` if any folder (top-level or
+        recursive subfolder) failed to list. Callers must not infer "this file
+        was removed from Box" from the returned map when the flag is ``False``,
+        because a transient listing failure would otherwise look like a deletion
+        of every file under the unreachable folder.
         """
         all_files: Dict[str, Dict[str, Any]] = {}
         file_ext_set = set(str(e).lower() for e in self.file_extensions) if self.file_extensions else set()
+        listing_complete = True
 
         def _crawl(fid: str, path: str = ""):
+            nonlocal listing_complete
             try:
                 folder = self.client.folder(fid).get(fields=["name", "id"])
                 current_path = f"{path}/{folder.name}" if path else folder.name
@@ -1007,12 +1015,13 @@ class BoxCrawler(Crawler):
                     elif item.type == "folder" and self.recursive:
                         _crawl(str(item.id), current_path)
             except Exception as e:
+                listing_complete = False
                 logging.error(f"Error crawling folder {fid} for incremental check: {e}")
 
         for folder_id in folder_ids:
             _crawl(str(folder_id))
 
-        return all_files
+        return all_files, listing_complete
 
     def _crawl_incremental(self, folder_ids: List[str]) -> None:
         """Run incremental crawl: only index files modified within hours_back, then delete removed files.
@@ -1022,6 +1031,8 @@ class BoxCrawler(Crawler):
         2. Filter files modified within hours_back window
         3. Download and index only those files through the full pipeline
         4. Compare Box files vs indexed.csv to detect and delete removed files
+           (skipped if the Box listing was incomplete, to avoid mass-deleting
+           documents when Box returns errors for whole folders).
         """
         delta = self._parse_hours_back(str(self.hours_back))
         cutoff = datetime.now(timezone.utc) - delta
@@ -1032,7 +1043,7 @@ class BoxCrawler(Crawler):
         logging.info("=" * 80)
 
         logging.info("Scanning Box folders for current file state...")
-        box_files = self._get_all_box_files(folder_ids)
+        box_files, listing_complete = self._get_all_box_files(folder_ids)
         logging.info(f"Found {len(box_files)} total files in Box")
 
         modified_files = {}
@@ -1138,7 +1149,15 @@ class BoxCrawler(Crawler):
             index_failed = 0
             logging.info("No modified files found — nothing to index")
 
-        self._delete_removed_from_vectara(box_files)
+        if listing_complete:
+            self._delete_removed_from_vectara(box_files)
+        else:
+            logging.warning(
+                "Skipping deletion pass: Box folder listing was incomplete "
+                "(one or more folders failed to list). Refusing to infer "
+                "deletions from a partial view of Box to avoid wiping the "
+                "corpus when Box returns errors."
+            )
 
         logging.info("=" * 80)
         logging.info("INCREMENTAL UPDATE COMPLETE")

--- a/tests/test_box_crawler.py
+++ b/tests/test_box_crawler.py
@@ -1,0 +1,155 @@
+import logging
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# box_crawler imports many heavy optional dependencies at module load time.
+# They are all present in requirements.txt (so CI imports the real modules),
+# but stub any that are missing so the units under test can be imported and
+# exercised in a lean environment. setdefault never shadows an installed module.
+for _optional in (
+    "psutil", "boxsdk", "slugify", "omegaconf", "nbconvert", "nbformat",
+    "markdown", "whisper", "PIL", "cairosvg", "openai", "anthropic", "magic",
+    "pandas", "bs4", "langdetect", "goose3", "goose3.text", "justext",
+    "pdf2image", "unstructured", "unstructured.partition",
+    "unstructured.partition.pdf", "unstructured.partition.html",
+    "unstructured.partition.pptx", "unstructured.partition.docx",
+    "nest_asyncio", "llama_parse", "gmft", "gmft.pdf_bindings", "gmft.auto",
+    "nltk", "pypdf",
+):
+    sys.modules.setdefault(_optional, MagicMock())
+
+from crawlers.box_crawler import BoxCrawler
+
+
+class FakeItem:
+    def __init__(self, item_id, name, item_type, modified_at="2026-01-01T00:00:00Z", size=10):
+        self.id = item_id
+        self.name = name
+        self.type = item_type
+        self.modified_at = modified_at
+        self.size = size
+
+
+class FakeFolder:
+    """Stand-in for a boxsdk Folder. `get()` returns folder metadata,
+    `get_items()` yields children. Either raises when `fail` is set, mirroring
+    a Box Shield 403 on the folder listing."""
+
+    def __init__(self, fid, name, items, fail=False):
+        self.id = fid
+        self.name = name
+        self._items = items
+        self.fail = fail
+
+    def get(self, fields=None):
+        if self.fail:
+            raise RuntimeError("403 Forbidden: forbidden_by_policy")
+        return self
+
+    def get_items(self, fields=None):
+        if self.fail:
+            raise RuntimeError("403 Forbidden: forbidden_by_policy")
+        return list(self._items)
+
+
+class FakeBoxClient:
+    def __init__(self, folders):
+        self._folders = {str(fid): folder for fid, folder in folders.items()}
+
+    def folder(self, fid):
+        return self._folders[str(fid)]
+
+
+def _make_crawler(client=None, recursive=True, file_extensions=None):
+    """Construct a BoxCrawler without running its real __init__."""
+    crawler = BoxCrawler.__new__(BoxCrawler)
+    crawler.client = client
+    crawler.recursive = recursive
+    crawler.file_extensions = file_extensions or []
+    return crawler
+
+
+class TestGetAllBoxFiles(unittest.TestCase):
+    """`_get_all_box_files` must report whether the listing was complete so the
+    caller never mistakes a Box outage for a folder full of deletions."""
+
+    def test_all_folders_listed_marks_complete(self):
+        client = FakeBoxClient({
+            "ROOT": FakeFolder("ROOT", "root", [
+                FakeItem("D1", "a.pdf", "file"),
+                FakeItem("D2", "b.pdf", "file"),
+            ]),
+        })
+        files, listing_complete = _make_crawler(client)._get_all_box_files(["ROOT"])
+        self.assertTrue(listing_complete)
+        self.assertEqual(set(files.keys()), {"D1", "D2"})
+
+    def test_top_level_folder_failure_marks_incomplete(self):
+        client = FakeBoxClient({"ROOT": FakeFolder("ROOT", "root", [], fail=True)})
+        files, listing_complete = _make_crawler(client)._get_all_box_files(["ROOT"])
+        self.assertFalse(listing_complete)
+        self.assertEqual(files, {})
+
+    def test_subfolder_failure_marks_incomplete_but_keeps_parent_files(self):
+        client = FakeBoxClient({
+            "ROOT": FakeFolder("ROOT", "root", [
+                FakeItem("D1", "a.pdf", "file"),
+                FakeItem("SUB", "sub", "folder"),
+            ]),
+            "SUB": FakeFolder("SUB", "sub", [FakeItem("D2", "b.pdf", "file")], fail=True),
+        })
+        files, listing_complete = _make_crawler(client)._get_all_box_files(["ROOT"])
+        self.assertFalse(listing_complete)
+        self.assertEqual(set(files.keys()), {"D1"})
+
+    def test_one_failed_folder_among_several_marks_incomplete(self):
+        client = FakeBoxClient({
+            "OK": FakeFolder("OK", "ok", [FakeItem("D1", "a.pdf", "file")]),
+            "BAD": FakeFolder("BAD", "bad", [], fail=True),
+        })
+        files, listing_complete = _make_crawler(client)._get_all_box_files(["OK", "BAD"])
+        self.assertFalse(listing_complete)
+        self.assertEqual(set(files.keys()), {"D1"})
+
+    def test_failed_folder_logs_error(self):
+        client = FakeBoxClient({"ROOT": FakeFolder("ROOT", "root", [], fail=True)})
+        with self.assertLogs(level=logging.ERROR) as cm:
+            _make_crawler(client)._get_all_box_files(["ROOT"])
+        self.assertTrue(any("Error crawling folder ROOT" in line for line in cm.output))
+
+
+class TestIncrementalDeleteGuard(unittest.TestCase):
+    """The deletion pass must run only when the Box listing was complete.
+    A 403 on the folder listing must never cascade into mass deletion."""
+
+    def _make(self):
+        crawler = BoxCrawler.__new__(BoxCrawler)
+        crawler.hours_back = "24h"
+        crawler.tracker = MagicMock()
+        crawler.tracker.get_indexed_file_ids.return_value = set()
+        crawler._delete_removed_from_vectara = MagicMock()
+        return crawler
+
+    def test_delete_skipped_when_listing_incomplete(self):
+        crawler = self._make()
+        crawler._get_all_box_files = MagicMock(return_value=({}, False))
+        crawler._crawl_incremental(["296961383989"])
+        crawler._delete_removed_from_vectara.assert_not_called()
+
+    def test_delete_runs_when_listing_complete(self):
+        crawler = self._make()
+        crawler._get_all_box_files = MagicMock(return_value=({}, True))
+        crawler._crawl_incremental(["296961383989"])
+        crawler._delete_removed_from_vectara.assert_called_once_with({})
+
+    def test_incomplete_listing_logs_skip_warning(self):
+        crawler = self._make()
+        crawler._get_all_box_files = MagicMock(return_value=({}, False))
+        with self.assertLogs(level=logging.WARNING) as cm:
+            crawler._crawl_incremental(["296961383989"])
+        self.assertTrue(any("Skipping deletion pass" in line for line in cm.output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_box_crawler.py
+++ b/tests/test_box_crawler.py
@@ -1,23 +1,20 @@
+import importlib.machinery
 import logging
 import sys
 import unittest
 from unittest.mock import MagicMock
 
-# box_crawler imports many heavy optional dependencies at module load time.
-# They are all present in requirements.txt (so CI imports the real modules),
-# but stub any that are missing so the units under test can be imported and
-# exercised in a lean environment. setdefault never shadows an installed module.
-for _optional in (
-    "psutil", "boxsdk", "slugify", "omegaconf", "nbconvert", "nbformat",
-    "markdown", "whisper", "PIL", "cairosvg", "openai", "anthropic", "magic",
-    "pandas", "bs4", "langdetect", "goose3", "goose3.text", "justext",
-    "pdf2image", "unstructured", "unstructured.partition",
-    "unstructured.partition.pdf", "unstructured.partition.html",
-    "unstructured.partition.pptx", "unstructured.partition.docx",
-    "nest_asyncio", "llama_parse", "gmft", "gmft.pdf_bindings", "gmft.auto",
-    "nltk", "pypdf",
-):
-    sys.modules.setdefault(_optional, MagicMock())
+# Mock only third-party deps that may be missing in the test env. Do NOT inject
+# MagicMocks for modules other tests rely on (slugify, pandas, omegaconf, ...) —
+# that pollutes sys.modules and makes the rest of the suite order-dependent.
+# `nbconvert` calls `importlib.util.find_spec("playwright")` at import time, so
+# the playwright mock needs a real ModuleSpec.
+for mod in ["cairosvg", "whisper", "pdf2image"]:
+    sys.modules.setdefault(mod, MagicMock())
+_playwright_mock = MagicMock()
+_playwright_mock.__spec__ = importlib.machinery.ModuleSpec("playwright", None)
+sys.modules.setdefault("playwright", _playwright_mock)
+sys.modules.setdefault("playwright.sync_api", MagicMock())
 
 from crawlers.box_crawler import BoxCrawler
 


### PR DESCRIPTION
## Summary
- Fixes a bug where a single failed Box folder listing (e.g. a Box Shield 403 on the configured folder) caused the incremental crawl to delete every previously-indexed document from the Vectara corpus.
- Root cause: `_get_all_box_files` caught all exceptions from `folder.get(...)` / `folder.get_items(...)` and returned an empty/partial map. `_delete_removed_from_vectara` then treated every `file_id` in `indexed.csv` as "removed from Box" and deleted it.
- `_get_all_box_files` now returns `(files_map, listing_complete)`. The flag flips to `False` on any caught listing exception (top-level or recursive subfolder). `_crawl_incremental` gates the delete pass on the flag and logs a warning when it skips deletion. New-file indexing is unaffected — files we positively saw in Box are still indexed.

## Real-world impact
A Broadcom HR Box corpus running this code dropped from ~1505 documents to 16 in a single cron run after a Box Shield Access Policy started returning 403 `forbidden_by_policy` on the folder listing. With this change the same scenario would surface as a logged warning and leave the corpus intact until Box access is restored.

## Test plan
- [x] Syntax/import check (`python -c "import ast; ast.parse(...)"`).
- [ ] Run incremental crawl against a folder the credential can list — confirm normal flow (`listing_complete=True`, deletions happen as before).
- [ ] Run incremental crawl against a folder the credential cannot list (simulate 403) — confirm `listing_complete=False`, no deletions occur, warning is logged.
- [ ] Mixed-folder crawl where one of several `folder_ids` 403s — confirm deletion pass is skipped (conservative behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)