### PR TITLE
website_crawler: Google auth for private Google Sites + Scrapy 2.14 redirect fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ vectara_ingest_output/data-private
 .run-env
 
 gcp_service_account.json
+google_storage_state.json

--- a/core/crawl_tracker.py
+++ b/core/crawl_tracker.py
@@ -23,7 +23,7 @@ _SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS documents (
     doc_id        TEXT NOT NULL,
     crawler_type  TEXT NOT NULL,
-    status        TEXT NOT NULL CHECK(status IN ('indexed', 'failed', 'skipped')),
+    status        TEXT NOT NULL CHECK(status IN ('indexed', 'failed', 'skipped', 'auth_required')),
     url           TEXT,
     title         TEXT,
     error         TEXT,
@@ -34,15 +34,16 @@ CREATE TABLE IF NOT EXISTS documents (
 CREATE INDEX IF NOT EXISTS idx_documents_crawler_status ON documents(crawler_type, status);
 
 CREATE TABLE IF NOT EXISTS crawl_state (
-    crawler_type  TEXT PRIMARY KEY,
-    status        TEXT NOT NULL DEFAULT 'running'
-                  CHECK(status IN ('running', 'stopped', 'completed', 'failed')),
-    started_at    TEXT,
-    updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
-    total_docs    INTEGER DEFAULT 0,
-    indexed_docs  INTEGER DEFAULT 0,
-    failed_docs   INTEGER DEFAULT 0,
-    skipped_docs  INTEGER DEFAULT 0
+    crawler_type        TEXT PRIMARY KEY,
+    status              TEXT NOT NULL DEFAULT 'running'
+                        CHECK(status IN ('running', 'stopped', 'completed', 'failed')),
+    started_at          TEXT,
+    updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    total_docs          INTEGER DEFAULT 0,
+    indexed_docs        INTEGER DEFAULT 0,
+    failed_docs         INTEGER DEFAULT 0,
+    skipped_docs        INTEGER DEFAULT 0,
+    auth_required_docs  INTEGER DEFAULT 0
 );
 """
 
@@ -65,6 +66,7 @@ class CrawlTracker:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA busy_timeout=5000")
         self._conn.executescript(_SCHEMA_SQL)
+        self._migrate_schema()
 
         # Upsert crawl_state row to 'running'
         self._conn.execute(
@@ -76,6 +78,52 @@ class CrawlTracker:
         )
         self._conn.commit()
         logger.info("CrawlTracker initialized: db=%s crawler=%s", db_path, crawler_type)
+
+    # ------------------------------------------------------------------
+    # Schema migration (idempotent; safe to call on every open)
+    # ------------------------------------------------------------------
+
+    def _migrate_schema(self):
+        """In-place upgrade for DBs created by older versions.
+
+        Adds the auth_required_docs counter and widens the documents.status
+        CHECK constraint to allow 'auth_required'. Existing rows are kept.
+        """
+        # 1) crawl_state.auth_required_docs column
+        cols = {r[1] for r in self._conn.execute("PRAGMA table_info(crawl_state)").fetchall()}
+        if "auth_required_docs" not in cols:
+            self._conn.execute(
+                "ALTER TABLE crawl_state ADD COLUMN auth_required_docs INTEGER DEFAULT 0"
+            )
+
+        # 2) documents.status CHECK constraint. SQLite has no ALTER for
+        #    CHECK constraints — inspect the stored CREATE TABLE statement
+        #    and recreate the table only if it predates 'auth_required'.
+        row = self._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='documents'"
+        ).fetchone()
+        if row and row[0] and "auth_required" not in row[0]:
+            self._conn.executescript("""
+                CREATE TABLE documents_new (
+                    doc_id        TEXT NOT NULL,
+                    crawler_type  TEXT NOT NULL,
+                    status        TEXT NOT NULL CHECK(status IN ('indexed', 'failed', 'skipped', 'auth_required')),
+                    url           TEXT,
+                    title         TEXT,
+                    error         TEXT,
+                    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (doc_id, crawler_type)
+                );
+                INSERT INTO documents_new
+                    (doc_id, crawler_type, status, url, title, error, created_at, updated_at)
+                    SELECT doc_id, crawler_type, status, url, title, error, created_at, updated_at
+                    FROM documents;
+                DROP TABLE documents;
+                ALTER TABLE documents_new RENAME TO documents;
+                CREATE INDEX IF NOT EXISTS idx_documents_crawler_status ON documents(crawler_type, status);
+            """)
+        self._conn.commit()
 
     # ------------------------------------------------------------------
     # Document tracking
@@ -127,7 +175,8 @@ class CrawlTracker:
 
             # Build counter updates: decrement old status, increment new
             counter_col = {"indexed": "indexed_docs", "failed": "failed_docs",
-                           "skipped": "skipped_docs"}
+                           "skipped": "skipped_docs",
+                           "auth_required": "auth_required_docs"}
             updates = []
             if prev:
                 old_col = counter_col.get(prev[0])
@@ -156,6 +205,16 @@ class CrawlTracker:
     def track_skipped(self, doc_id: str, url: str = "", title: str = "",
                       reason: str = ""):
         self._track_document(doc_id, "skipped", url=url, title=title, error=reason)
+
+    def track_auth_required(self, doc_id: str, url: str = "", title: str = "",
+                            reason: str = ""):
+        """Record that a URL couldn't be indexed because it required auth.
+
+        Distinct from track_failed: a sign-in redirect isn't a broken page,
+        it's a missing credential. Surfacing this separately lets the user
+        see at a glance how many URLs are gated and need auth configured.
+        """
+        self._track_document(doc_id, "auth_required", url=url, title=title, error=reason)
 
     # ------------------------------------------------------------------
     # Graceful shutdown
@@ -210,7 +269,8 @@ class CrawlTracker:
     def get_stats(self) -> dict:
         with self._lock:
             row = self._conn.execute(
-                """SELECT total_docs, indexed_docs, failed_docs, skipped_docs, status
+                """SELECT total_docs, indexed_docs, failed_docs, skipped_docs,
+                          auth_required_docs, status
                    FROM crawl_state WHERE crawler_type=?""",
                 (self.crawler_type,),
             ).fetchone()
@@ -221,7 +281,8 @@ class CrawlTracker:
             "indexed_docs": row[1],
             "failed_docs": row[2],
             "skipped_docs": row[3],
-            "status": row[4],
+            "auth_required_docs": row[4],
+            "status": row[5],
         }
 
     # ------------------------------------------------------------------
@@ -266,6 +327,10 @@ class CrawlTrackerActor:
     def track_skipped(self, doc_id: str, url: str = "", title: str = "",
                       reason: str = ""):
         self._tracker.track_skipped(doc_id, url=url, title=title, reason=reason)
+
+    def track_auth_required(self, doc_id: str, url: str = "", title: str = "",
+                            reason: str = ""):
+        self._tracker.track_auth_required(doc_id, url=url, title=title, reason=reason)
 
     def get_stats(self) -> dict:
         return self._tracker.get_stats()

--- a/core/indexer.py
+++ b/core/indexer.py
@@ -39,9 +39,9 @@ from core.image_processor import ImageProcessor
 
 
 from core.indexer_utils import (
-    get_chunking_config, extract_last_modified, create_upload_files_dict, 
+    get_chunking_config, extract_last_modified, create_upload_files_dict,
     handle_file_upload_response, safe_file_cleanup, prepare_file_metadata, store_file,
-    normalize_url_for_metadata
+    normalize_url_for_metadata, auth_redirect_reason
 )
 from core.web_extractor_base import create_web_extractor
 from core.file_processor import FileProcessor
@@ -81,6 +81,10 @@ class Indexer:
         # start of every index_file() call. Callers can read this after a False
         # return to enrich their drop/error records.
         self.last_error: Optional[str] = None
+        # When index_url skips a page because it was redirected to an IdP /
+        # sign-in form, this holds the reason string. Reset on every
+        # index_url call so callers can read it after a False return.
+        self.last_skip_reason: Optional[str] = None
         self.x_source = f'vectara-ingest-{self.cfg.crawling.crawler_type}'
         self.scrape_method = scrape_method  # Store scrape_method for web extractor
         self.whisper_model = None
@@ -572,6 +576,7 @@ class Indexer:
             bool: True if the upload was successful, False otherwise.
         """
         succeeded = False
+        self.last_skip_reason = None
         if html_processing is None:
             html_processing = {}
         st = time.time()
@@ -662,6 +667,18 @@ class Indexer:
                     remove_code=self.remove_code,
                     html_processing=html_processing,
                 )
+                # If the fetch was bounced to a sign-in / IdP page, treat it
+                # as a crawl failure: do not index the login form's HTML.
+                auth_reason = auth_redirect_reason(url, res.get('url'))
+                if auth_reason:
+                    logger.warning(
+                        f"Skipping {url}: {auth_reason} ({res.get('url')}). "
+                        f"This usually means the page requires authentication; "
+                        f"configure website_crawler.google_auth / saml_auth "
+                        f"(or grant access to the configured account) to crawl it."
+                    )
+                    self.last_skip_reason = auth_reason
+                    return False
                 html = res['html']
                 text = res['text']
                 doc_title = res['title']

--- a/core/indexer_utils.py
+++ b/core/indexer_utils.py
@@ -263,6 +263,28 @@ def auth_redirect_reason(original_url: str, final_url: str) -> Optional[str]:
     return None
 
 
+def is_auth_host(url: str) -> bool:
+    """True if `url`'s host matches a known identity-provider netloc.
+
+    Use this to skip URLs that are sign-in / account-chooser pages reached
+    by a direct link (e.g. an `accounts.google.com/SignOutOptions` link
+    embedded in a partially-authenticated page), where `auth_redirect_reason`
+    does not fire because no netloc change occurred during the fetch.
+    """
+    if not url:
+        return False
+    try:
+        host = urlparse(url).netloc.lower()
+    except Exception:
+        return False
+    if not host:
+        return False
+    for netloc in _AUTH_NETLOCS:
+        if host == netloc or host.endswith("." + netloc):
+            return True
+    return False
+
+
 def prepare_file_metadata(metadata: Dict[str, Any], filename: str, static_metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Prepare file metadata by adding filename and static metadata"""
     if static_metadata:

--- a/core/indexer_utils.py
+++ b/core/indexer_utils.py
@@ -7,7 +7,7 @@ import json
 from typing import Dict, Any, Optional
 from email.utils import parsedate_to_datetime
 from datetime import datetime
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 from bs4 import BeautifulSoup
 from omegaconf import OmegaConf
 
@@ -220,6 +220,47 @@ def normalize_url_for_metadata(url: str) -> str:
     if url and isinstance(url, str):
         return unquote(url)
     return url
+
+
+# Known identity-provider netlocs. Matched by equality OR as a suffix
+# preceded by '.' so subdomains like 'tenant.okta.com' are caught while
+# 'fakeokta.com' is not.
+_AUTH_NETLOCS = (
+    "accounts.google.com",
+    "login.microsoftonline.com",
+    "login.live.com",
+    "login.windows.net",
+    "signin.aws.amazon.com",
+    "auth0.com",
+    "okta.com",
+    "oktapreview.com",
+    "onelogin.com",
+    "pingone.com",
+)
+
+
+def auth_redirect_reason(original_url: str, final_url: str) -> Optional[str]:
+    """Detect that a fetch was bounced into a sign-in / identity-provider page.
+
+    Returns a short human-readable reason string when the netloc changed
+    during the fetch and the new netloc matches a known IDP; otherwise
+    returns None. The check is intentionally conservative: same-domain
+    /login redirects are not flagged, because some sites legitimately
+    serve login content under their own domain.
+    """
+    if not original_url or not final_url:
+        return None
+    try:
+        orig = urlparse(original_url).netloc.lower()
+        final = urlparse(final_url).netloc.lower()
+    except Exception:
+        return None
+    if not orig or not final or orig == final:
+        return None
+    for netloc in _AUTH_NETLOCS:
+        if final == netloc or final.endswith("." + netloc):
+            return f"redirected to identity-provider {final}"
+    return None
 
 
 def prepare_file_metadata(metadata: Dict[str, Any], filename: str, static_metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:

--- a/core/spider.py
+++ b/core/spider.py
@@ -19,6 +19,7 @@ from scrapy.spiders.sitemap import iterloc
 
 
 from core.indexer import Indexer
+from core.indexer_utils import auth_redirect_reason
 from core.utils import img_extensions, audio_extensions, video_extensions, doc_extensions, archive_extensions, url_matches_patterns
 
 # Configure logging
@@ -59,6 +60,16 @@ def recursive_crawl(url: str, depth: int,
 
     try:
         res = indexer.fetch_page_contents(url)
+        # If the fetch was bounced to a sign-in / IdP page, drop link extraction:
+        # the page we landed on is the IdP's login form, not real content, and
+        # following its links would pollute the discovery set with sign-in chrome.
+        auth_reason = auth_redirect_reason(url, res.get('url', url))
+        if auth_reason:
+            logger.warning(
+                f"Skipping discovery from {url}: {auth_reason} ({res.get('url')}). "
+                f"Configure website_crawler.google_auth / saml_auth to crawl it."
+            )
+            return visited
         new_urls = [urljoin(url, u) if _url_is_relative(u) else u for u in res['links']]  # convert all new URLs to absolute URLs
         new_urls = [u for u in new_urls 
                     if      u not in visited and u.startswith('http') and 
@@ -180,6 +191,17 @@ class LinkSpider(scrapy.Spider):
         return self.is_valid_by_regex(url)
 
     def parse(self, response):
+        # If Scrapy followed redirects, redirect_urls[0] is the original request
+        # URL; otherwise the request URL itself is the original.
+        original_url = response.meta.get('redirect_urls', [response.url])[0]
+        auth_reason = auth_redirect_reason(original_url, response.url)
+        if auth_reason:
+            logger.warning(
+                f"Skipping discovery from {original_url}: {auth_reason} ({response.url}). "
+                f"Configure website_crawler.google_auth / saml_auth to crawl it."
+            )
+            return
+
         extract_links = True
         parsed_response_url = urlparse(response.url)
         response_path_lower = parsed_response_url.path.lower() # Get lowercase path

--- a/core/spider.py
+++ b/core/spider.py
@@ -86,7 +86,7 @@ DISALLOWED_REDIRECT_EXTENSIONS = tuple(
 )
 class FilterRedirectsByTypeMiddleware(RedirectMiddleware):
 
-    def _redirect(self, redirected, request, spider, reason):
+    def _redirect(self, redirected, request, reason):
         redirect_to_url = redirected.url
         should_ignore_this_redirect = False
 
@@ -95,13 +95,12 @@ class FilterRedirectsByTypeMiddleware(RedirectMiddleware):
             path_lower = parsed_redirect_to_url.path.lower()
 
             if path_lower.endswith(DISALLOWED_REDIRECT_EXTENSIONS):
-                spider.logger.info(
+                logger.info(
                     f"REDIRECT_FILTER: Ignoring redirect from '{request.url}' to disallowed file type: '{redirect_to_url}'"
                 )
                 should_ignore_this_redirect = True
         except Exception as e:
-            # This block now only catches truly unexpected errors during your *checking logic* (e.g., urlparse failure)
-            spider.logger.error(
+            logger.error(
                 f"REDIRECT_FILTER: Unexpected error during file type check for redirect from '{request.url}' to '{redirect_to_url}': {e}. "
                 f"Allowing redirect to proceed by default to avoid breaking other functionalities."
             )
@@ -109,7 +108,7 @@ class FilterRedirectsByTypeMiddleware(RedirectMiddleware):
         if should_ignore_this_redirect:
             raise IgnoreRequest(f"Redirect target '{redirect_to_url}' is a disallowed file type; original request '{request.url}' will be ignored.")
         else:
-            return super()._redirect(redirected, request, spider, reason)
+            return super()._redirect(redirected, request, reason)
 
 class LinkSpider(scrapy.Spider):
     name = "link_spider"

--- a/core/spider.py
+++ b/core/spider.py
@@ -19,7 +19,7 @@ from scrapy.spiders.sitemap import iterloc
 
 
 from core.indexer import Indexer
-from core.indexer_utils import auth_redirect_reason
+from core.indexer_utils import auth_redirect_reason, is_auth_host
 from core.utils import img_extensions, audio_extensions, video_extensions, doc_extensions, archive_extensions, url_matches_patterns
 
 # Configure logging
@@ -130,7 +130,7 @@ class LinkSpider(scrapy.Spider):
         positive_regexes: list[str],
         negative_regexes: list[str],
         max_depth: int = 1,
-        cookies: dict = None,
+        cookies: list = None,
         *args, **kwargs
     ):
         """
@@ -138,11 +138,15 @@ class LinkSpider(scrapy.Spider):
         positive_regexes: list of strings, e.g. '["^https?://.*foo","bar$"]'
         negative_regexes: list of strings, e.g. '["/logout","/private"]'
         max_depth: integer, how many hops from any start_url
+        cookies: list of {name, value, domain?, path?, secure?} dicts; passed
+            to each Scrapy Request so CookieMiddleware can scope host-bound
+            cookies (`__Host-*`, `__Secure-*`) correctly on cross-domain
+            redirects.
         """
         super().__init__(*args, **kwargs)
         self.start_urls = start_urls
         self.max_depth = int(max_depth)
-        self.cookies = cookies or {}
+        self.cookies = cookies or []
         try:
             self.positive_patterns = [re.compile(r) for r in positive_regexes]
             self.negative_patterns = [re.compile(r) for r in negative_regexes]
@@ -188,6 +192,14 @@ class LinkSpider(scrapy.Spider):
 
         if not parsed_url.scheme.lower() in ['http', 'https']:
             return False
+
+        # Never follow links into identity-provider hosts (e.g. account
+        # chooser, sign-out option pages). These leak in via authenticated
+        # response bodies and pollute the discovered URL list without ever
+        # producing real content.
+        if is_auth_host(url):
+            return False
+
         return self.is_valid_by_regex(url)
 
     def parse(self, response):
@@ -195,6 +207,11 @@ class LinkSpider(scrapy.Spider):
         # URL; otherwise the request URL itself is the original.
         original_url = response.meta.get('redirect_urls', [response.url])[0]
         auth_reason = auth_redirect_reason(original_url, response.url)
+        # Also catch the case where the response URL is itself on an IDP host
+        # without a netloc change (e.g. a direct link to accounts.google.com/
+        # SignOutOptions found in an authenticated page body).
+        if not auth_reason and is_auth_host(response.url):
+            auth_reason = f"response URL is identity-provider host {urlparse(response.url).netloc}"
         if auth_reason:
             logger.warning(
                 f"Skipping discovery from {original_url}: {auth_reason} ({response.url}). "
@@ -244,7 +261,7 @@ def run_link_spider(
     negative_regexes: List[str],
     max_depth:        int = 1,
     extra_settings:   dict | None = None,
-    cookies:          dict | None = None,
+    cookies:          list | None = None,
 ) -> List[str]:
     """
     Blocking, in-process runner that:
@@ -323,7 +340,7 @@ def run_link_spider_isolated(
     negative_regexes: List[str],
     max_depth: int = 1,
     extra_settings: dict | None = None,
-    cookies: dict | None = None,
+    cookies: list | None = None,
 ) -> list[str]:
     """
     Launches run_link_spider(...) in a fresh Python process so that

--- a/core/web_content_extractor.py
+++ b/core/web_content_extractor.py
@@ -24,7 +24,14 @@ class WebContentExtractor(WebExtractorBase):
         # Track consecutive failures for adaptive reset
         self.consecutive_failures = 0
         self.max_consecutive_failures = 3
-        
+        # When True, skip the unauthenticated `requests.get` prefetch and go
+        # straight to the Playwright path. Flipped on by
+        # `crawlers.website_crawler._apply_auth_to_indexer` when SAML or
+        # google_auth is wired in — otherwise the static prefetch follows
+        # redirects to the IdP sign-in page, returns >500 chars, and
+        # short-circuits the authenticated browser path.
+        self.skip_static_prefetch = False
+
         if browser is None:
             self._setup_browser()
     
@@ -391,43 +398,48 @@ class WebContentExtractor(WebExtractorBase):
         # JS-evaluating document.innerText gives rich text but page.content() gives
         # framework tags, not real HTML. We fall through to the browser only if static
         # content is sparse (<500 chars), indicating a true SPA needing JS rendering.
-        try:
-            from bs4 import BeautifulSoup
-            static_resp = requests.get(url, headers=get_headers(self.cfg), timeout=30, allow_redirects=True)
-            static_resp.raise_for_status()
-            if 'text/html' in static_resp.headers.get('content-type', '').lower():
-                soup = BeautifulSoup(static_resp.text, 'html.parser')
-                static_text = soup.get_text(separator=' ', strip=True)
-                if len(static_text.strip()) > 500:
-                    result['html'] = static_resp.text
-                    result['url'] = static_resp.url
-                    result['title'] = soup.title.string if soup.title else ''
-                    result['text'] = static_text
-                    result['links'] = [a['href'] for a in soup.find_all('a', href=True)]
-                    # Extract images with same filtering as the browser path
-                    from urllib.parse import urljoin
-                    for img_tag in soup.find_all('img'):
-                        src = img_tag.get('src', '')
-                        if not src or src.startswith('data:') or src.startswith('blob:'):
-                            continue
-                        try:
-                            w = int(img_tag.get('width', '0') or '0')
-                        except (ValueError, TypeError):
-                            w = 0
-                        try:
-                            h = int(img_tag.get('height', '0') or '0')
-                        except (ValueError, TypeError):
-                            h = 0
-                        if (w > 0 and w < 10) or (h > 0 and h < 10):
-                            continue
-                        result['images'].append({'src': urljoin(url, src), 'alt': img_tag.get('alt', '')})
-                    logger.info(f"Static fetch used for {url}: {len(static_text)} chars")
-                    logger.info(f"For crawled page {url}: images = {len(result['images'])}, "
-                                f"tables = {len(result['tables'])}, links = {len(result['links'])}")
-                    return result
-                logger.debug(f"Static fetch for {url} too sparse ({len(static_text)} chars), falling back to browser")
-        except Exception as e:
-            logger.debug(f"Static pre-fetch failed for {url}, using browser: {e}")
+        # When `skip_static_prefetch` is set (auth configured), bypass this path
+        # entirely — unauthenticated requests.get follows redirects to the IdP
+        # sign-in page, which passes the 500-char threshold and would otherwise
+        # prevent the authenticated Playwright context from ever running.
+        if not self.skip_static_prefetch:
+            try:
+                from bs4 import BeautifulSoup
+                static_resp = requests.get(url, headers=get_headers(self.cfg), timeout=30, allow_redirects=True)
+                static_resp.raise_for_status()
+                if 'text/html' in static_resp.headers.get('content-type', '').lower():
+                    soup = BeautifulSoup(static_resp.text, 'html.parser')
+                    static_text = soup.get_text(separator=' ', strip=True)
+                    if len(static_text.strip()) > 500:
+                        result['html'] = static_resp.text
+                        result['url'] = static_resp.url
+                        result['title'] = soup.title.string if soup.title else ''
+                        result['text'] = static_text
+                        result['links'] = [a['href'] for a in soup.find_all('a', href=True)]
+                        # Extract images with same filtering as the browser path
+                        from urllib.parse import urljoin
+                        for img_tag in soup.find_all('img'):
+                            src = img_tag.get('src', '')
+                            if not src or src.startswith('data:') or src.startswith('blob:'):
+                                continue
+                            try:
+                                w = int(img_tag.get('width', '0') or '0')
+                            except (ValueError, TypeError):
+                                w = 0
+                            try:
+                                h = int(img_tag.get('height', '0') or '0')
+                            except (ValueError, TypeError):
+                                h = 0
+                            if (w > 0 and w < 10) or (h > 0 and h < 10):
+                                continue
+                            result['images'].append({'src': urljoin(url, src), 'alt': img_tag.get('alt', '')})
+                        logger.info(f"Static fetch used for {url}: {len(static_text)} chars")
+                        logger.info(f"For crawled page {url}: images = {len(result['images'])}, "
+                                    f"tables = {len(result['tables'])}, links = {len(result['links'])}")
+                        return result
+                    logger.debug(f"Static fetch for {url} too sparse ({len(static_text)} chars), falling back to browser")
+            except Exception as e:
+                logger.debug(f"Static pre-fetch failed for {url}, using browser: {e}")
 
         page = context = None
         # Cap at 90s: OS-level Chromium crash (SIGKILL) leaves websocket open, causing

--- a/crawlers/auth/google_bootstrap.py
+++ b/crawlers/auth/google_bootstrap.py
@@ -4,10 +4,21 @@ Run OUTSIDE the Docker container (Playwright needs a display for headed mode):
 
     python -m crawlers.auth.google_bootstrap --output /path/to/google_storage_state.json
 
-The script opens a real Chromium window, waits for you to sign in to Google
-(including 2FA / SSO / account-chooser steps), then writes the resulting cookies
-and localStorage to `--output` as a JSON file. Mount that file into the
-container at the path you set in `website_crawler.google_auth.storage_state_path`.
+The script opens a real Google Chrome window (installed Chrome, not Playwright's
+bundled Chromium — Chromium is reliably flagged by Cloudflare / Google bot
+detection), waits for you to sign in to Google (including 2FA / SSO /
+account-chooser steps), then writes the resulting cookies and localStorage to
+`--output` as a JSON file. Mount that file into the container at the path you
+set in `website_crawler.google_auth.storage_state_path`.
+
+A persistent Chrome profile is kept under `--profile-dir` so subsequent runs
+look like a returning user and usually skip CAPTCHAs / Cloudflare challenges
+entirely.
+
+Prerequisites (one-time):
+
+    pip install playwright
+    playwright install chrome
 
 Re-run whenever the stored session expires (typical for Workspace SSO: a few
 weeks). The crawler surfaces a clear error message when this happens.
@@ -51,6 +62,25 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=300,
         help="Max seconds to wait for sign-in to complete (default: %(default)s).",
     )
+    p.add_argument(
+        "--profile-dir",
+        default=os.path.expanduser("~/.cache/vectara-ingest/google_bootstrap_profile"),
+        help=(
+            "Persistent Chrome profile directory. Reusing the same directory "
+            "across runs avoids repeated CAPTCHAs / Cloudflare challenges "
+            "(default: %(default)s)."
+        ),
+    )
+    p.add_argument(
+        "--channel",
+        default="chrome",
+        help=(
+            "Playwright browser channel to launch. Defaults to installed "
+            "Google Chrome ('chrome'), which is far less likely to be flagged "
+            "as a bot than bundled Chromium. Pass an empty string to use "
+            "Playwright's bundled Chromium instead."
+        ),
+    )
     return p.parse_args(argv)
 
 
@@ -63,7 +93,7 @@ def run(argv: list[str] | None = None) -> int:
     except ImportError:
         logging.error(
             "Playwright is not installed. Install it locally with "
-            "`pip install playwright && playwright install chromium`."
+            "`pip install playwright && playwright install chrome`."
         )
         return 2
 
@@ -72,13 +102,27 @@ def run(argv: list[str] | None = None) -> int:
     if output_dir and not os.path.isdir(output_dir):
         os.makedirs(output_dir, exist_ok=True)
 
-    logging.info("Opening Chromium for Google sign-in. Complete the login flow in the browser window.")
+    profile_dir = os.path.abspath(args.profile_dir)
+    os.makedirs(profile_dir, exist_ok=True)
+
+    channel = args.channel or None
+    logging.info(
+        f"Opening {channel or 'bundled Chromium'} for Google sign-in. "
+        f"Complete the login flow in the browser window."
+    )
     logging.info(f"Target start URL: {args.start_url}")
+    logging.info(f"Using persistent profile: {profile_dir}")
     logging.info(f"Will save storage state to: {output_path}")
 
+    launch_args = ["--disable-blink-features=AutomationControlled"]
+
     with sync_playwright() as pw:
-        browser = pw.chromium.launch(headless=False)
-        context = browser.new_context()
+        context = pw.chromium.launch_persistent_context(
+            user_data_dir=profile_dir,
+            channel=channel,
+            headless=False,
+            args=launch_args,
+        )
         page = context.new_page()
         page.goto(args.start_url, wait_until="domcontentloaded")
 
@@ -91,12 +135,12 @@ def run(argv: list[str] | None = None) -> int:
             )
         except Exception as e:
             logging.error(f"Sign-in did not complete within {args.timeout_seconds}s: {e}")
-            browser.close()
+            context.close()
             return 1
 
         context.storage_state(path=output_path)
         logging.info(f"Saved Google session to {output_path}")
-        browser.close()
+        context.close()
 
     return 0
 

--- a/crawlers/auth/google_bootstrap.py
+++ b/crawlers/auth/google_bootstrap.py
@@ -1,0 +1,105 @@
+"""One-time interactive bootstrap to capture a Google session for headless crawling.
+
+Run OUTSIDE the Docker container (Playwright needs a display for headed mode):
+
+    python -m crawlers.auth.google_bootstrap --output /path/to/google_storage_state.json
+
+The script opens a real Chromium window, waits for you to sign in to Google
+(including 2FA / SSO / account-chooser steps), then writes the resulting cookies
+and localStorage to `--output` as a JSON file. Mount that file into the
+container at the path you set in `website_crawler.google_auth.storage_state_path`.
+
+Re-run whenever the stored session expires (typical for Workspace SSO: a few
+weeks). The crawler surfaces a clear error message when this happens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="python -m crawlers.auth.google_bootstrap",
+        description="Capture a Google sign-in session for the website crawler.",
+    )
+    p.add_argument(
+        "--output",
+        required=True,
+        help="Path to write the Playwright storage_state JSON file.",
+    )
+    p.add_argument(
+        "--start-url",
+        default="https://sites.google.com",
+        help="URL to open for sign-in (default: %(default)s).",
+    )
+    p.add_argument(
+        "--success-url-contains",
+        default="sites.google.com",
+        help=(
+            "When the browser URL contains this substring AND is NOT on "
+            "accounts.google.com, sign-in is considered complete and the "
+            "session is saved (default: %(default)s)."
+        ),
+    )
+    p.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=300,
+        help="Max seconds to wait for sign-in to complete (default: %(default)s).",
+    )
+    return p.parse_args(argv)
+
+
+def run(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = _parse_args(argv)
+
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        logging.error(
+            "Playwright is not installed. Install it locally with "
+            "`pip install playwright && playwright install chromium`."
+        )
+        return 2
+
+    output_path = os.path.abspath(args.output)
+    output_dir = os.path.dirname(output_path)
+    if output_dir and not os.path.isdir(output_dir):
+        os.makedirs(output_dir, exist_ok=True)
+
+    logging.info("Opening Chromium for Google sign-in. Complete the login flow in the browser window.")
+    logging.info(f"Target start URL: {args.start_url}")
+    logging.info(f"Will save storage state to: {output_path}")
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=False)
+        context = browser.new_context()
+        page = context.new_page()
+        page.goto(args.start_url, wait_until="domcontentloaded")
+
+        deadline_ms = args.timeout_seconds * 1000
+        try:
+            page.wait_for_function(
+                "(needle) => location.href.includes(needle) && !location.href.includes('accounts.google.com')",
+                arg=args.success_url_contains,
+                timeout=deadline_ms,
+            )
+        except Exception as e:
+            logging.error(f"Sign-in did not complete within {args.timeout_seconds}s: {e}")
+            browser.close()
+            return 1
+
+        context.storage_state(path=output_path)
+        logging.info(f"Saved Google session to {output_path}")
+        browser.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/crawlers/auth/google_manager.py
+++ b/crawlers/auth/google_manager.py
@@ -48,7 +48,7 @@ VALID_MODES = ("service_account", "oauth_user")
 DOCKER_STORAGE_STATE_PATH = "/home/vectara/env/google_storage_state.json"
 
 
-def get_credentials(
+def get_service_account_credentials(
     delegated_user: str,
     credentials_file: str,
     scopes: Optional[List[str]] = None,
@@ -153,12 +153,13 @@ class GoogleAuthManager:
             raise ValueError(
                 "google_auth requires 'credentials_file' in secrets to mint API "
                 "credentials (set GOOGLE_CREDENTIALS_FILE in secrets.toml). "
-                "Cookie-only crawls of sites.google.com do not need this — "
-                "only callers of get_credentials()/get_authenticated_session() do."
+                "Cookie-only crawls of sites.google.com do not need this — only "
+                "callers of GoogleAuthManager.get_credentials() / "
+                "GoogleAuthManager.get_authenticated_session() do."
             )
 
         if self.mode == "service_account":
-            self._credentials = get_credentials(
+            self._credentials = get_service_account_credentials(
                 self.delegated_user,
                 self.credentials_file,
                 scopes=self.scopes,

--- a/crawlers/auth/google_manager.py
+++ b/crawlers/auth/google_manager.py
@@ -41,6 +41,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_SCOPES = ["openid", "email", "https://www.googleapis.com/auth/userinfo.profile"]
 VALID_MODES = ("service_account", "oauth_user")
 
+# Fixed in-container path where `run.sh` mounts the host's storage_state JSON.
+# Matches the gdrive `credentials.json` pattern. When this path exists at init
+# time, it wins over any `storage_state_path` set in YAML — the YAML field is
+# treated as a host path (for `run.sh` to mount), not a container path.
+DOCKER_STORAGE_STATE_PATH = "/home/vectara/env/google_storage_state.json"
+
 
 def get_credentials(
     delegated_user: str,
@@ -117,15 +123,23 @@ class GoogleAuthManager:
                 "google_auth mode 'service_account' requires 'delegated_user' in config"
             )
 
+        # `credentials_file` is only needed for Bearer-token API calls
+        # (Drive / Sites APIs). The common case — crawling sites.google.com
+        # via persisted storage_state cookies — does not call any Google API,
+        # so we defer the check until something actually asks for credentials.
         self.credentials_file = self.secrets.get("credentials_file")
-        if not self.credentials_file:
-            raise ValueError(
-                "google_auth requires 'credentials_file' in secrets "
-                "(set GOOGLE_CREDENTIALS_FILE in secrets.toml)"
-            )
 
         self.scopes = list(self.config.get("scopes") or DEFAULT_SCOPES)
-        self.storage_state_path = self.config.get("storage_state_path")
+
+        # In Docker, `run.sh` mounts the host file to DOCKER_STORAGE_STATE_PATH.
+        # When that mount is present, prefer it over the YAML value (which is the
+        # host-side path, not the container path). Falls back to the YAML value
+        # for native runs and back-compat with explicit container paths.
+        config_storage_state_path = self.config.get("storage_state_path")
+        if config_storage_state_path and os.path.exists(DOCKER_STORAGE_STATE_PATH):
+            self.storage_state_path = DOCKER_STORAGE_STATE_PATH
+        else:
+            self.storage_state_path = config_storage_state_path
 
         self._credentials: Optional[object] = None
 
@@ -134,6 +148,14 @@ class GoogleAuthManager:
     def get_credentials(self):
         if self._credentials is not None:
             return self._credentials
+
+        if not self.credentials_file:
+            raise ValueError(
+                "google_auth requires 'credentials_file' in secrets to mint API "
+                "credentials (set GOOGLE_CREDENTIALS_FILE in secrets.toml). "
+                "Cookie-only crawls of sites.google.com do not need this — "
+                "only callers of get_credentials()/get_authenticated_session() do."
+            )
 
         if self.mode == "service_account":
             self._credentials = get_credentials(

--- a/crawlers/auth/google_manager.py
+++ b/crawlers/auth/google_manager.py
@@ -1,0 +1,255 @@
+"""Google authentication for `website_crawler` — mirrors `SAMLAuthManager`.
+
+Two auth modes are supported, configured via `website_crawler.google_auth.mode`:
+
+- `service_account`: SA key file + Workspace domain-wide delegation, impersonating
+  `delegated_user`. Workspace admin must grant DWD to the SA.
+- `oauth_user`: OAuth user refresh token (same shape as `gdrive_crawler`'s
+  `get_oauth_credentials`). One-time consent, refresh token persisted.
+
+A Google service-account bearer token is NOT accepted by `sites.google.com`
+content URLs — those require browser session cookies. The bridge between
+credentials and cookies is Playwright `storage_state`: a one-time interactive
+login (see `google_bootstrap.py`) writes a JSON file; subsequent runs reuse it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from contextlib import contextmanager
+from typing import List, Optional
+
+import requests
+
+try:
+    from playwright.sync_api import sync_playwright
+    PLAYWRIGHT_AVAILABLE = True
+except ImportError:
+    sync_playwright = None  # type: ignore[assignment]
+    PLAYWRIGHT_AVAILABLE = False
+    logging.warning("Playwright not available. Google authentication will be disabled.")
+
+from google.oauth2 import service_account
+from google.oauth2.credentials import Credentials
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_SCOPES = ["openid", "email", "https://www.googleapis.com/auth/userinfo.profile"]
+VALID_MODES = ("service_account", "oauth_user")
+
+
+def get_credentials(
+    delegated_user: str,
+    credentials_file: str,
+    scopes: Optional[List[str]] = None,
+) -> service_account.Credentials:
+    """Service account with domain-wide delegation, impersonating `delegated_user`.
+
+    Deliberately does NOT use `core.utils.get_docker_or_local_path` — that helper
+    silently swaps in `/home/vectara/env/credentials.json` when present, which
+    would conflict with `gdrive_crawler` if both run in the same image with
+    different SAs.
+    """
+    effective_scopes = scopes or DEFAULT_SCOPES
+    creds = service_account.Credentials.from_service_account_file(
+        credentials_file, scopes=effective_scopes
+    )
+    return creds.with_subject(delegated_user)
+
+
+def get_oauth_credentials(
+    credentials_file: str,
+    scopes: Optional[List[str]] = None,
+) -> Credentials:
+    """OAuth user credentials from a token JSON file.
+
+    Refreshes the access token if expired and writes the refreshed token back
+    to the same file (matches `gdrive_crawler.get_oauth_credentials` behavior).
+    """
+    effective_scopes = scopes or DEFAULT_SCOPES
+    with open(credentials_file, "r") as f:
+        token_data = json.load(f)
+
+    creds = Credentials.from_authorized_user_info(token_data, effective_scopes)
+
+    if creds.expired and creds.refresh_token:
+        from google.auth.transport.requests import Request as GoogleRequest
+
+        creds.refresh(GoogleRequest())
+        with open(credentials_file, "w") as f:
+            json.dump(
+                {
+                    "token": creds.token,
+                    "refresh_token": creds.refresh_token,
+                    "token_uri": creds.token_uri,
+                    "client_id": creds.client_id,
+                    "client_secret": creds.client_secret,
+                    "scopes": creds.scopes,
+                },
+                f,
+                indent=2,
+            )
+        logger.info("Refreshed and persisted OAuth token")
+
+    return creds
+
+
+class GoogleAuthManager:
+    """Google authentication for website_crawler. See module docstring for modes."""
+
+    def __init__(self, config: dict, secrets: dict):
+        self.config = config or {}
+        self.secrets = secrets or {}
+
+        self.mode = self.config.get("mode")
+        if self.mode not in VALID_MODES:
+            raise ValueError(
+                f"google_auth.mode must be one of {VALID_MODES}, got: {self.mode!r}"
+            )
+
+        self.delegated_user = self.config.get("delegated_user")
+        if self.mode == "service_account" and not self.delegated_user:
+            raise ValueError(
+                "google_auth mode 'service_account' requires 'delegated_user' in config"
+            )
+
+        self.credentials_file = self.secrets.get("credentials_file")
+        if not self.credentials_file:
+            raise ValueError(
+                "google_auth requires 'credentials_file' in secrets "
+                "(set GOOGLE_CREDENTIALS_FILE in secrets.toml)"
+            )
+
+        self.scopes = list(self.config.get("scopes") or DEFAULT_SCOPES)
+        self.storage_state_path = self.config.get("storage_state_path")
+
+        self._credentials: Optional[object] = None
+
+    # --- credentials & API session -------------------------------------------------
+
+    def get_credentials(self):
+        if self._credentials is not None:
+            return self._credentials
+
+        if self.mode == "service_account":
+            self._credentials = get_credentials(
+                self.delegated_user,
+                self.credentials_file,
+                scopes=self.scopes,
+            )
+        else:
+            self._credentials = get_oauth_credentials(
+                self.credentials_file,
+                scopes=self.scopes,
+            )
+        return self._credentials
+
+    def get_authenticated_session(self) -> requests.Session:
+        """Returns a `requests.Session` with `Authorization: Bearer <token>`.
+
+        For Google API calls (Drive, Sites APIs) — NOT for `sites.google.com`
+        content URLs, which require browser cookies. Use
+        `get_authenticated_cookies()` for those.
+        """
+        creds = self.get_credentials()
+        if getattr(creds, "expired", False) and hasattr(creds, "refresh"):
+            from google.auth.transport.requests import Request as GoogleRequest
+
+            creds.refresh(GoogleRequest())
+
+        session = requests.Session()
+        session.headers["Authorization"] = f"Bearer {creds.token}"
+        return session
+
+    # --- browser cookies -----------------------------------------------------------
+
+    def get_authenticated_cookies(self) -> dict:
+        """Open Playwright with the persisted `storage_state`, navigate to
+        `sites.google.com`, and capture `.google.com` cookies for Scrapy.
+
+        Raises RuntimeError with a clear pointer to `google_bootstrap` if the
+        storage state is missing, never captured, or has expired.
+        """
+        if not self.storage_state_path:
+            raise RuntimeError(
+                "google_auth.storage_state_path is required. Run "
+                "`python -m crawlers.auth.google_bootstrap --output <path>` "
+                "to capture an initial Google session, then set "
+                "google_auth.storage_state_path in your config."
+            )
+
+        if not os.path.exists(self.storage_state_path):
+            raise RuntimeError(
+                f"Google storage_state file not found at {self.storage_state_path}. "
+                f"Run `python -m crawlers.auth.google_bootstrap "
+                f"--output {self.storage_state_path}` to capture it."
+            )
+
+        if not PLAYWRIGHT_AVAILABLE:
+            raise RuntimeError(
+                "Playwright is not available — install playwright to use google_auth."
+            )
+
+        with self._playwright_browser() as (_browser, context, page):
+            try:
+                page.goto(
+                    "https://sites.google.com",
+                    wait_until="domcontentloaded",
+                    timeout=30000,
+                )
+                page.wait_for_load_state("networkidle", timeout=15000)
+            except Exception as e:
+                logger.warning(
+                    f"Google navigation did not fully settle (continuing anyway): {e}"
+                )
+
+            current = page.url or ""
+            if "accounts.google.com" in current or "ServiceLogin" in current:
+                raise RuntimeError(
+                    f"Stored Google session has expired (landed on {current}). "
+                    f"Re-run `python -m crawlers.auth.google_bootstrap "
+                    f"--output {self.storage_state_path}`."
+                )
+
+            raw_cookies = context.cookies()
+
+        cookie_dict = {}
+        for c in raw_cookies:
+            domain = (c.get("domain") or "").lower()
+            if domain.endswith(".google.com") or domain == "google.com":
+                cookie_dict[c["name"]] = c["value"]
+
+        logger.info(f"Captured {len(cookie_dict)} Google session cookies for crawler use")
+        return cookie_dict
+
+    @contextmanager
+    def _playwright_browser(self):
+        pw = None
+        browser = None
+        context = None
+        page = None
+        try:
+            pw = sync_playwright().start()
+            browser = pw.chromium.launch(
+                headless=True,
+                args=["--no-sandbox", "--disable-dev-shm-usage"],
+            )
+            context = browser.new_context(storage_state=self.storage_state_path)
+            page = context.new_page()
+            yield browser, context, page
+        finally:
+            try:
+                if page is not None:
+                    page.close()
+                if context is not None:
+                    context.close()
+                if browser is not None:
+                    browser.close()
+                if pw is not None:
+                    pw.stop()
+            except Exception as cleanup_error:
+                logger.debug(f"Playwright cleanup error: {cleanup_error}")

--- a/crawlers/auth/google_manager.py
+++ b/crawlers/auth/google_manager.py
@@ -189,9 +189,16 @@ class GoogleAuthManager:
 
     # --- browser cookies -----------------------------------------------------------
 
-    def get_authenticated_cookies(self) -> dict:
+    def get_authenticated_cookies(self) -> List[dict]:
         """Open Playwright with the persisted `storage_state`, navigate to
-        `sites.google.com`, and capture `.google.com` cookies for Scrapy.
+        `sites.google.com`, and capture Google-family cookies for Scrapy.
+
+        Returns a list of `{name, value, domain, path, secure}` dicts. The
+        full attribute set is required because Scrapy's CookieMiddleware
+        needs `domain` to scope `__Host-*` / `__Secure-*` cookies to their
+        original host — flattening to `{name: value}` causes
+        `accounts.google.com` cookies to leak to `sites.google.com` on
+        redirects, which Google rejects with `CookieMismatch`.
 
         Raises RuntimeError with a clear pointer to `google_bootstrap` if the
         storage state is missing, never captured, or has expired.
@@ -239,14 +246,25 @@ class GoogleAuthManager:
 
             raw_cookies = context.cookies()
 
-        cookie_dict = {}
+        cookies: List[dict] = []
         for c in raw_cookies:
             domain = (c.get("domain") or "").lower()
+            # Match `.google.com` (covers `accounts.google.com`,
+            # `sites.google.com`, etc.) and the bare `google.com` host. Drop
+            # everything else so unrelated cookies from the storage_state
+            # (Rippling, YouTube subdomains, etc.) can't leak to Google on
+            # cross-domain redirects.
             if domain.endswith(".google.com") or domain == "google.com":
-                cookie_dict[c["name"]] = c["value"]
+                cookies.append({
+                    "name": c["name"],
+                    "value": c["value"],
+                    "domain": c["domain"],
+                    "path": c.get("path", "/"),
+                    "secure": bool(c.get("secure", False)),
+                })
 
-        logger.info(f"Captured {len(cookie_dict)} Google session cookies for crawler use")
-        return cookie_dict
+        logger.info(f"Captured {len(cookies)} Google session cookies for crawler use")
+        return cookies
 
     @contextmanager
     def _playwright_browser(self):

--- a/crawlers/website_crawler.py
+++ b/crawlers/website_crawler.py
@@ -12,6 +12,7 @@ from core.utils import (
 from core.indexer import Indexer
 from core.spider import run_link_spider_isolated, recursive_crawl, sitemap_to_urls
 from crawlers.auth.saml_manager import SAMLAuthManager
+from crawlers.auth.google_manager import GoogleAuthManager
 
 import ray
 
@@ -27,6 +28,7 @@ class PageCrawlWorker(object):
         website_crawler_cfg = self.cfg.get('website_crawler', {})
         self.html_processing = website_crawler_cfg.get('html_processing', {})
         self.saml_config = website_crawler_cfg.get('saml_auth')
+        self.google_config = website_crawler_cfg.get('google_auth')
         self.scrape_method = website_crawler_cfg.get('scrape_method', 'playwright')
 
     def setup(self):
@@ -73,6 +75,32 @@ class PageCrawlWorker(object):
         else:
             logging.info(f"[Worker {os.getpid()}] SAML not configured. Using standard session.")
             # Indexer will use its default session
+
+        # Initialize Google authenticated session if configured (independent of SAML).
+        if self.google_config:
+            worker_pid = os.getpid()
+            logging.info(f"[Worker {worker_pid}] Google authentication is enabled. Initializing GoogleAuthManager.")
+
+            google_secrets = {}
+            website_crawler_cfg = self.cfg.get('website_crawler', {})
+            if 'google_credentials_file' in website_crawler_cfg:
+                google_secrets['credentials_file'] = website_crawler_cfg['google_credentials_file']
+            else:
+                raise ValueError(
+                    "Google authentication requires 'GOOGLE_CREDENTIALS_FILE' in secrets.toml"
+                )
+
+            try:
+                google_manager = GoogleAuthManager(config=self.google_config, secrets=google_secrets)
+                # API-bearer Session (for Drive/Sites API calls); does NOT authenticate sites.google.com pages.
+                google_session = google_manager.get_authenticated_session()
+                # Apply Bearer header to the indexer session so any API-style fetches work.
+                if self.indexer.session is None or self.indexer.session is self.session:
+                    self.indexer.session = google_session
+                logging.info(f"[Worker {worker_pid}] Google authentication successful (Bearer session ready).")
+            except Exception as e:
+                logging.error(f"[Worker {worker_pid}] Fatal Google authentication failure: {e}")
+                raise
     
     def cleanup(self):
         """Cleanup resources when worker is done"""
@@ -106,7 +134,9 @@ class WebsiteCrawler(Crawler):
     def __init__(self, cfg, *args, **kwargs):
         super().__init__(cfg, *args, **kwargs)
         self.saml_session = None
+        self.google_session = None
         self._setup_saml_auth()
+        self._setup_google_auth()
     
     def _setup_saml_auth(self):
         """Initialize SAML authentication if configured"""
@@ -161,6 +191,51 @@ class WebsiteCrawler(Crawler):
         else:
             raise Exception("SAML authentication requires 'SAML_USERNAME' and 'SAML_PASSWORD' in secrets.toml")
 
+    def _setup_google_auth(self):
+        """Initialize a Bearer-token Session if google_auth is configured.
+
+        Note: this is for API-style calls; sites.google.com PAGE crawling needs
+        browser cookies, obtained separately via `_get_scrapy_google_cookies`.
+        """
+        google_config = self.cfg.website_crawler.get("google_auth")
+        if not google_config:
+            return
+
+        logger.info("Google authentication configured, initializing...")
+        try:
+            secrets_dict = self._get_google_secrets()
+            google_manager = GoogleAuthManager(google_config, secrets_dict)
+            self.google_session = google_manager.get_authenticated_session()
+            logger.info("Google authentication successful (Bearer session ready)")
+        except Exception as e:
+            logger.error(f"Google authentication failed: {e}")
+            raise
+
+    def _get_google_secrets(self):
+        """Extract Google auth secrets stamped onto cfg by ingest.py."""
+        if hasattr(self.cfg.website_crawler, 'google_credentials_file'):
+            return {
+                'credentials_file': self.cfg.website_crawler.google_credentials_file,
+            }
+        raise Exception(
+            "Google authentication requires 'GOOGLE_CREDENTIALS_FILE' in secrets.toml"
+        )
+
+    def _get_scrapy_google_cookies(self):
+        """Capture browser session cookies for sites.google.com via Playwright
+        + persisted storage_state. Returns a {name: value} dict for Scrapy."""
+        google_config = self.cfg.website_crawler.get("google_auth")
+        if not google_config:
+            return None
+
+        try:
+            secrets_dict = self._get_google_secrets()
+            google_manager = GoogleAuthManager(google_config, secrets_dict)
+            return google_manager.get_authenticated_cookies()
+        except Exception as e:
+            logger.error(f"Failed to get Google cookies: {e}")
+            return None
+
     def _get_scrapy_saml_cookies(self):
         """
         Get SAML authentication cookies using SAMLAuthManager's Playwright method.
@@ -197,27 +272,33 @@ class WebsiteCrawler(Crawler):
         self._remove_old_content_if_needed(urls_to_crawl)
 
     def _configure_indexer_session(self):
-        """Configure indexer to use SAML session if available."""
-        # Configure indexer to use SAML session if available
+        """Configure indexer to use SAML and/or Google authenticated sessions."""
+        # Attach SAML session if present.
         if self.saml_session and hasattr(self.indexer, 'session'):
             self.indexer.session = self.saml_session
             logger.info("Configured indexer to use SAML authenticated session")
-        
-        # Override web extractor's context creation to include SAML cookies
-        if self.saml_session:
-            # Initialize web extractor to ensure it exists
+        elif self.google_session and hasattr(self.indexer, 'session'):
+            # Bearer-token Session is useful for Drive/Sites API calls, not for
+            # sites.google.com page content (those need browser cookies — see
+            # `_get_scrapy_google_cookies`). Only attach if SAML did not.
+            self.indexer.session = self.google_session
+            logger.info("Configured indexer to use Google Bearer-token session")
+
+        # Override web extractor's context creation to inject any auth cookies.
+        if self.saml_session or self.google_session:
             self.indexer._init_processors()
-            
+
             if hasattr(self.indexer, 'web_extractor') and self.indexer.web_extractor:
                 original_new_context = self.indexer.web_extractor.browser.new_context
-                
+
                 def new_context_with_auth(*args, **kwargs):
                     context = original_new_context(*args, **kwargs)
-                    self._transfer_session_cookies_to_context(context, self.saml_session)
+                    if self.saml_session:
+                        self._transfer_session_cookies_to_context(context, self.saml_session)
                     return context
-                    
+
                 self.indexer.web_extractor.browser.new_context = new_context_with_auth
-                logger.info("Configured web extractor to use SAML authenticated cookies")
+                logger.info("Configured web extractor to use authenticated cookies")
 
     def _discover_urls(self) -> list:
         """
@@ -233,20 +314,41 @@ class WebsiteCrawler(Crawler):
         self.html_processing = self.cfg.website_crawler.get('html_processing', {})
         max_depth = self.cfg.website_crawler.get("max_depth", 3)
 
-        # Determine crawl method and handle SAML compatibility
+        # Determine crawl method and handle SAML / Google auth for Scrapy.
         crawl_method = self.cfg.website_crawler.get("crawl_method", "internal")
-        scrapy_cookies = None
-        
-        # Try SAML authentication for Scrapy if configured
+        scrapy_cookies: dict = {}
+
         if crawl_method == "scrapy" and self.cfg.website_crawler.get("saml_auth"):
             logger.info("SAML detected with Scrapy - attempting Playwright-based SAML authentication")
-            scrapy_cookies = self._get_scrapy_saml_cookies()
-            
-            if scrapy_cookies:
-                logger.info(f"Playwright-based SAML successful! Using Scrapy with {len(scrapy_cookies)} cookies")
+            saml_cookies = self._get_scrapy_saml_cookies()
+            if saml_cookies:
+                scrapy_cookies.update(saml_cookies)
+                logger.info(f"Playwright-based SAML successful! Got {len(saml_cookies)} cookies")
             else:
-                logger.warning("Playwright-based SAML failed. Falling back to internal crawler with requests-based SAML.")
+                logger.warning(
+                    "Playwright-based SAML failed. Falling back to internal crawler with requests-based SAML."
+                )
                 crawl_method = "internal"
+
+        if crawl_method == "scrapy" and self.cfg.website_crawler.get("google_auth"):
+            logger.info("Google auth detected with Scrapy - loading persisted Google session cookies")
+            google_cookies = self._get_scrapy_google_cookies()
+            if google_cookies:
+                scrapy_cookies.update(google_cookies)
+                logger.info(f"Loaded {len(google_cookies)} Google session cookies")
+            else:
+                # Google cookies are required to crawl sites.google.com. Without
+                # them, every Scrapy request 302s into accounts.google.com and we
+                # discover 0 URLs. Surface this loudly rather than silently
+                # producing an empty crawl.
+                raise RuntimeError(
+                    "Google authentication is configured but no session cookies were obtained. "
+                    "Run `python -m crawlers.auth.google_bootstrap --output <path>` to capture a Google session."
+                )
+
+        # Pass None instead of an empty dict so the spider keeps default behavior
+        # for crawls that have no auth configured.
+        scrapy_cookies = scrapy_cookies or None
         
         # Execute crawling based on method
         if crawl_method == "scrapy":

--- a/crawlers/website_crawler.py
+++ b/crawlers/website_crawler.py
@@ -41,43 +41,50 @@ def _transfer_session_to_context(context, session):
             logger.warning(f"Failed to add cookie {cookie.name} to Playwright context: {e}")
 
 
-def _transfer_cookie_dict_to_context(context, cookies, domain='.google.com'):
-    """Forward a `{name: value}` cookie dict to a Playwright context.
-
-    Used for Google session cookies captured via `storage_state` — those are
-    pre-filtered to `.google.com` by `GoogleAuthManager.get_authenticated_cookies`.
-    """
-    if not cookies:
-        return
-    items = [
-        {'name': name, 'value': value, 'domain': domain, 'path': '/'}
-        for name, value in cookies.items()
-    ]
-    try:
-        context.add_cookies(items)
-    except Exception as e:
-        logger.warning(f"Failed to inject session cookies into Playwright context: {e}")
-
-
-def _apply_auth_to_indexer(indexer, saml_session=None, google_cookies=None):
+def _apply_auth_to_indexer(
+    indexer,
+    saml_session=None,
+    google_cookies=None,
+    google_storage_state_path=None,
+):
     """Propagate auth to an Indexer so both `session` (requests) and
     `web_extractor` (Playwright) issue authenticated fetches.
 
     Used by `WebsiteCrawler._configure_indexer_session` (parent process,
     discovery-side indexer) and by `PageCrawlWorker.setup` (per-worker
     indexer in Ray actor or single-process mode).
+
+    For Google auth, the Playwright context is loaded from the captured
+    `storage_state` JSON. Re-injecting individual cookies via `add_cookies`
+    fails for Google's `__Host-*` / `__Secure-*` cookies (CDP rejects the
+    batch because `__Host-` cookies must be sent without a Domain attribute
+    and `__Secure-` cookies require `Secure=true`). Playwright's
+    `storage_state` path preserves the original cookie attributes verbatim.
     """
     if saml_session and hasattr(indexer, 'session'):
         indexer.session = saml_session
         logger.info("Configured indexer to use SAML authenticated session")
 
     if google_cookies and hasattr(indexer, 'session') and indexer.session is not None:
-        indexer.session.cookies.update(google_cookies)
+        # Use create_cookie + set_cookie so each cookie retains its
+        # domain/path/secure scoping in the requests cookie jar. A flat
+        # `cookies.update({name: value})` would attach every Google cookie
+        # to every host the session talks to, leaking host-bound cookies
+        # (`__Host-*`) to wrong domains on redirects.
+        for c in google_cookies:
+            cookie = requests.cookies.create_cookie(
+                name=c["name"],
+                value=c["value"],
+                domain=c.get("domain", ""),
+                path=c.get("path", "/"),
+                secure=bool(c.get("secure", False)),
+            )
+            indexer.session.cookies.set_cookie(cookie)
         logger.info(
             f"Merged {len(google_cookies)} Google session cookies into indexer session"
         )
 
-    if not (saml_session or google_cookies):
+    if not (saml_session or google_storage_state_path):
         return
 
     indexer._init_processors()
@@ -85,14 +92,20 @@ def _apply_auth_to_indexer(indexer, saml_session=None, google_cookies=None):
         original_new_context = indexer.web_extractor.browser.new_context
 
         def new_context_with_auth(*args, **kwargs):
+            if google_storage_state_path:
+                kwargs.setdefault('storage_state', google_storage_state_path)
             context = original_new_context(*args, **kwargs)
             if saml_session:
                 _transfer_session_to_context(context, saml_session)
-            if google_cookies:
-                _transfer_cookie_dict_to_context(context, google_cookies)
             return context
 
         indexer.web_extractor.browser.new_context = new_context_with_auth
+        # Auth is wired in via Playwright `storage_state` / per-context cookie
+        # transfer. Tell the extractor to skip the unauthenticated `requests.get`
+        # prefetch in `fetch_page_contents` — without this, the prefetch follows
+        # redirects to the IdP sign-in page (~1KB of HTML, >500 chars) and
+        # short-circuits the authenticated browser path entirely.
+        indexer.web_extractor.skip_static_prefetch = True
         logger.info("Configured web extractor to inject authenticated cookies")
 
 
@@ -170,7 +183,11 @@ class PageCrawlWorker(object):
             try:
                 google_manager = GoogleAuthManager(config=self.google_config, secrets=google_secrets)
                 google_cookies = google_manager.get_authenticated_cookies()
-                _apply_auth_to_indexer(self.indexer, google_cookies=google_cookies)
+                _apply_auth_to_indexer(
+                    self.indexer,
+                    google_cookies=google_cookies,
+                    google_storage_state_path=google_manager.storage_state_path,
+                )
                 logging.info(
                     f"[Worker {worker_pid}] Captured {len(google_cookies)} Google session cookies."
                 )
@@ -222,6 +239,7 @@ class WebsiteCrawler(Crawler):
         super().__init__(cfg, *args, **kwargs)
         self.saml_session = None
         self.google_cookies = None
+        self.google_storage_state_path = None
         self._setup_saml_auth()
         self._setup_google_auth()
 
@@ -277,6 +295,7 @@ class WebsiteCrawler(Crawler):
         try:
             google_manager = GoogleAuthManager(google_config, secrets_dict)
             self.google_cookies = google_manager.get_authenticated_cookies()
+            self.google_storage_state_path = google_manager.storage_state_path
             logger.info(
                 f"Captured {len(self.google_cookies)} Google session cookies."
             )
@@ -287,17 +306,23 @@ class WebsiteCrawler(Crawler):
     def _get_scrapy_saml_cookies(self):
         """
         Get SAML authentication cookies using SAMLAuthManager's Playwright method.
-        Returns cookies that can be used with Scrapy for fast crawling.
+        Returns a list of `{name, value}` dicts in the shape Scrapy expects.
+        Domain/secure attributes are absent because SAMLAuthManager flattens
+        cookies at capture time — Scrapy will treat them as host-bound to
+        each request URL, which is correct for single-IdP SAML flows.
         """
         saml_config = self.cfg.website_crawler.get("saml_auth")
         if not saml_config:
             return None
-            
+
         try:
             secrets_dict = self._get_saml_secrets()
             saml_manager = SAMLAuthManager(saml_config, secrets_dict)
-            return saml_manager.get_authenticated_cookies()
-            
+            flat = saml_manager.get_authenticated_cookies()
+            if not flat:
+                return None
+            return [{"name": k, "value": v} for k, v in flat.items()]
+
         except Exception as e:
             logger.error(f"Failed to get SAML cookies: {e}")
             return None
@@ -326,6 +351,7 @@ class WebsiteCrawler(Crawler):
             self.indexer,
             saml_session=self.saml_session,
             google_cookies=self.google_cookies,
+            google_storage_state_path=self.google_storage_state_path,
         )
 
     def _discover_urls(self) -> list:
@@ -343,14 +369,18 @@ class WebsiteCrawler(Crawler):
         max_depth = self.cfg.website_crawler.get("max_depth", 3)
 
         # Determine crawl method and handle SAML / Google auth for Scrapy.
+        # Cookies are passed as a list of dicts (`{name, value, domain, path,
+        # secure}`) so Scrapy's CookieMiddleware can enforce per-cookie
+        # scoping on redirects — `__Host-*` and other host-bound Google
+        # cookies must not leak to `sites.google.com` from `accounts.google.com`.
         crawl_method = self.cfg.website_crawler.get("crawl_method", "internal")
-        scrapy_cookies: dict = {}
+        scrapy_cookies: list = []
 
         if crawl_method == "scrapy" and self.cfg.website_crawler.get("saml_auth"):
             logger.info("SAML detected with Scrapy - attempting Playwright-based SAML authentication")
             saml_cookies = self._get_scrapy_saml_cookies()
             if saml_cookies:
-                scrapy_cookies.update(saml_cookies)
+                scrapy_cookies.extend(saml_cookies)
                 logger.info(f"Playwright-based SAML successful! Got {len(saml_cookies)} cookies")
             else:
                 logger.warning(
@@ -361,7 +391,7 @@ class WebsiteCrawler(Crawler):
         if crawl_method == "scrapy" and self.cfg.website_crawler.get("google_auth"):
             logger.info("Google auth detected with Scrapy - forwarding captured session cookies")
             if self.google_cookies:
-                scrapy_cookies.update(self.google_cookies)
+                scrapy_cookies.extend(self.google_cookies)
                 logger.info(f"Loaded {len(self.google_cookies)} Google session cookies")
             else:
                 # Google cookies are required to crawl sites.google.com. Without
@@ -373,8 +403,8 @@ class WebsiteCrawler(Crawler):
                     "Run `python -m crawlers.auth.google_bootstrap --output <path>` to capture a Google session."
                 )
 
-        # Pass None instead of an empty dict so the spider keeps default behavior
-        # for crawls that have no auth configured.
+        # Pass None instead of an empty list so the spider keeps default
+        # behavior for crawls that have no auth configured.
         scrapy_cookies = scrapy_cookies or None
         
         # Execute crawling based on method
@@ -383,7 +413,7 @@ class WebsiteCrawler(Crawler):
         else:
             return self._discover_urls_with_internal_crawler(base_urls, max_depth, keep_query_params)
 
-    def _discover_urls_with_scrapy(self, base_urls: list, max_depth: int, scrapy_cookies: dict) -> list:
+    def _discover_urls_with_scrapy(self, base_urls: list, max_depth: int, scrapy_cookies: list) -> list:
         """Discover URLs using Scrapy crawler."""
         logger.info("Using Scrapy to crawl the website")
         

--- a/crawlers/website_crawler.py
+++ b/crawlers/website_crawler.py
@@ -10,6 +10,7 @@ from core.utils import (
     setup_logging, get_docker_or_local_path, url_matches_patterns, normalize_vectara_endpoint
 )
 from core.indexer import Indexer
+from core.indexer_utils import normalize_url_for_metadata
 from core.spider import run_link_spider_isolated, recursive_crawl, sitemap_to_urls
 from crawlers.auth.saml_manager import SAMLAuthManager
 from crawlers.auth.google_manager import GoogleAuthManager
@@ -17,6 +18,82 @@ from crawlers.auth.google_manager import GoogleAuthManager
 import ray
 
 logger = logging.getLogger(__name__)
+
+
+def _transfer_session_to_context(context, session):
+    """Forward cookies from a `requests.Session` to a Playwright context."""
+    if not session or not hasattr(session, 'cookies'):
+        return
+    for cookie in session.cookies:
+        attrs = {
+            'name': cookie.name,
+            'value': cookie.value,
+            'domain': cookie.domain or '',
+            'path': cookie.path or '/',
+        }
+        if getattr(cookie, 'secure', False):
+            attrs['secure'] = True
+        if getattr(cookie, 'expires', None):
+            attrs['expires'] = cookie.expires
+        try:
+            context.add_cookies([attrs])
+        except Exception as e:
+            logger.warning(f"Failed to add cookie {cookie.name} to Playwright context: {e}")
+
+
+def _transfer_cookie_dict_to_context(context, cookies, domain='.google.com'):
+    """Forward a `{name: value}` cookie dict to a Playwright context.
+
+    Used for Google session cookies captured via `storage_state` — those are
+    pre-filtered to `.google.com` by `GoogleAuthManager.get_authenticated_cookies`.
+    """
+    if not cookies:
+        return
+    items = [
+        {'name': name, 'value': value, 'domain': domain, 'path': '/'}
+        for name, value in cookies.items()
+    ]
+    try:
+        context.add_cookies(items)
+    except Exception as e:
+        logger.warning(f"Failed to inject session cookies into Playwright context: {e}")
+
+
+def _apply_auth_to_indexer(indexer, saml_session=None, google_cookies=None):
+    """Propagate auth to an Indexer so both `session` (requests) and
+    `web_extractor` (Playwright) issue authenticated fetches.
+
+    Used by `WebsiteCrawler._configure_indexer_session` (parent process,
+    discovery-side indexer) and by `PageCrawlWorker.setup` (per-worker
+    indexer in Ray actor or single-process mode).
+    """
+    if saml_session and hasattr(indexer, 'session'):
+        indexer.session = saml_session
+        logger.info("Configured indexer to use SAML authenticated session")
+
+    if google_cookies and hasattr(indexer, 'session') and indexer.session is not None:
+        indexer.session.cookies.update(google_cookies)
+        logger.info(
+            f"Merged {len(google_cookies)} Google session cookies into indexer session"
+        )
+
+    if not (saml_session or google_cookies):
+        return
+
+    indexer._init_processors()
+    if hasattr(indexer, 'web_extractor') and indexer.web_extractor:
+        original_new_context = indexer.web_extractor.browser.new_context
+
+        def new_context_with_auth(*args, **kwargs):
+            context = original_new_context(*args, **kwargs)
+            if saml_session:
+                _transfer_session_to_context(context, saml_session)
+            if google_cookies:
+                _transfer_cookie_dict_to_context(context, google_cookies)
+            return context
+
+        indexer.web_extractor.browser.new_context = new_context_with_auth
+        logger.info("Configured web extractor to inject authenticated cookies")
 
 
 class PageCrawlWorker(object):
@@ -76,28 +153,27 @@ class PageCrawlWorker(object):
             logging.info(f"[Worker {os.getpid()}] SAML not configured. Using standard session.")
             # Indexer will use its default session
 
-        # Initialize Google authenticated session if configured (independent of SAML).
+        # Initialize Google authenticated cookies if configured (independent of SAML).
+        # A Bearer-token API session is NOT useful here: sites.google.com content
+        # URLs reject Bearer auth (only browser cookies work). We capture cookies
+        # from the persisted storage_state and inject them into both the indexer's
+        # requests.Session and its Playwright web_extractor.
         if self.google_config:
             worker_pid = os.getpid()
-            logging.info(f"[Worker {worker_pid}] Google authentication is enabled. Initializing GoogleAuthManager.")
+            logging.info(f"[Worker {worker_pid}] Google authentication enabled. Capturing storage_state cookies.")
 
             google_secrets = {}
             website_crawler_cfg = self.cfg.get('website_crawler', {})
             if 'google_credentials_file' in website_crawler_cfg:
                 google_secrets['credentials_file'] = website_crawler_cfg['google_credentials_file']
-            else:
-                raise ValueError(
-                    "Google authentication requires 'GOOGLE_CREDENTIALS_FILE' in secrets.toml"
-                )
 
             try:
                 google_manager = GoogleAuthManager(config=self.google_config, secrets=google_secrets)
-                # API-bearer Session (for Drive/Sites API calls); does NOT authenticate sites.google.com pages.
-                google_session = google_manager.get_authenticated_session()
-                # Apply Bearer header to the indexer session so any API-style fetches work.
-                if self.indexer.session is None or self.indexer.session is self.session:
-                    self.indexer.session = google_session
-                logging.info(f"[Worker {worker_pid}] Google authentication successful (Bearer session ready).")
+                google_cookies = google_manager.get_authenticated_cookies()
+                _apply_auth_to_indexer(self.indexer, google_cookies=google_cookies)
+                logging.info(
+                    f"[Worker {worker_pid}] Captured {len(google_cookies)} Google session cookies."
+                )
             except Exception as e:
                 logging.error(f"[Worker {worker_pid}] Fatal Google authentication failure: {e}")
                 raise
@@ -107,10 +183,17 @@ class PageCrawlWorker(object):
         if hasattr(self, 'indexer'):
             self.indexer.cleanup()
 
+    # Return codes from process(). PageCrawlWorker runs in a Ray actor, so
+    # the dispatch side can't read `self.indexer.last_skip_reason` directly —
+    # we encode the outcome in the integer return value instead.
+    RESULT_INDEXED = 0
+    RESULT_FAILED = 1
+    RESULT_AUTH_REQUIRED = 2
+
     def process(self, url: str, source: str):
         if not self.indexer:
             logging.error(f"[Worker {os.getpid()}] Indexer not set up. Call setup() before process().")
-            return -1
+            return self.RESULT_FAILED
 
         metadata = {"source": source, "url": url}
         logging.info(f"[Worker {os.getpid()}] Crawling and indexing {url}")
@@ -127,59 +210,38 @@ class PageCrawlWorker(object):
             logging.error(
                 f"[Worker {os.getpid()}] Error while indexing {url}: {e}, traceback={traceback.format_exc()}"
             )
-            return -1
-        return 0 if succeeded else 1
+            return self.RESULT_FAILED
+        if succeeded:
+            return self.RESULT_INDEXED
+        if getattr(self.indexer, "last_skip_reason", None):
+            return self.RESULT_AUTH_REQUIRED
+        return self.RESULT_FAILED
 
 class WebsiteCrawler(Crawler):
     def __init__(self, cfg, *args, **kwargs):
         super().__init__(cfg, *args, **kwargs)
         self.saml_session = None
-        self.google_session = None
+        self.google_cookies = None
         self._setup_saml_auth()
         self._setup_google_auth()
-    
+
     def _setup_saml_auth(self):
         """Initialize SAML authentication if configured"""
         saml_config = self.cfg.website_crawler.get("saml_auth")
         if not saml_config:
             return
-            
+
         logger.info("SAML authentication configured, initializing...")
-        
+
         try:
             secrets_dict = self._get_saml_secrets()
             saml_manager = SAMLAuthManager(saml_config, secrets_dict)
             self.saml_session = saml_manager.get_authenticated_session()
             logger.info("SAML authentication successful")
-            
+
         except Exception as e:
             logger.error(f"SAML authentication failed: {e}")
             raise
-    
-    def _transfer_session_cookies_to_context(self, context, session):
-        """Transfer cookies from requests session to Playwright context"""
-        if not session or not hasattr(session, 'cookies'):
-            return
-            
-        for cookie in session.cookies:
-            cookie_dict = {
-                'name': cookie.name,
-                'value': cookie.value,
-                'domain': cookie.domain or '',
-                'path': cookie.path or '/',
-            }
-            
-            # Add optional cookie attributes if present
-            if hasattr(cookie, 'secure') and cookie.secure:
-                cookie_dict['secure'] = True
-            if hasattr(cookie, 'expires') and cookie.expires:
-                cookie_dict['expires'] = cookie.expires
-                
-            try:
-                context.add_cookies([cookie_dict])
-                logger.debug(f"Added cookie {cookie.name} to Playwright context")
-            except Exception as e:
-                logger.warning(f"Failed to add cookie {cookie.name}: {e}")
 
     def _get_saml_secrets(self):
         """Extract SAML secrets from config (loaded from secrets.toml)."""
@@ -188,53 +250,39 @@ class WebsiteCrawler(Crawler):
                 'username': self.cfg.website_crawler.saml_username,
                 'password': self.cfg.website_crawler.saml_password
             }
-        else:
-            raise Exception("SAML authentication requires 'SAML_USERNAME' and 'SAML_PASSWORD' in secrets.toml")
+        raise ValueError("SAML authentication requires 'SAML_USERNAME' and 'SAML_PASSWORD' in secrets.toml")
 
     def _setup_google_auth(self):
-        """Initialize a Bearer-token Session if google_auth is configured.
+        """Capture `sites.google.com` session cookies once at crawler init.
 
-        Note: this is for API-style calls; sites.google.com PAGE crawling needs
-        browser cookies, obtained separately via `_get_scrapy_google_cookies`.
+        These cookies are the only thing that authenticates requests against
+        `sites.google.com` content URLs — Bearer tokens are rejected there.
+        They are injected into both the indexer's `requests.Session` and its
+        Playwright `web_extractor` by `_configure_indexer_session`, and also
+        forwarded to Scrapy in the discovery path via `_discover_urls`.
+
+        `GOOGLE_CREDENTIALS_FILE` is optional here: it is only consumed when
+        someone calls `GoogleAuthManager.get_authenticated_session()` for
+        Drive / Sites API access. Cookie-only crawls do not need it.
         """
         google_config = self.cfg.website_crawler.get("google_auth")
         if not google_config:
             return
 
-        logger.info("Google authentication configured, initializing...")
+        logger.info("Google authentication configured, capturing storage_state cookies...")
+        secrets_dict = {}
+        if hasattr(self.cfg.website_crawler, 'google_credentials_file'):
+            secrets_dict['credentials_file'] = self.cfg.website_crawler.google_credentials_file
+
         try:
-            secrets_dict = self._get_google_secrets()
             google_manager = GoogleAuthManager(google_config, secrets_dict)
-            self.google_session = google_manager.get_authenticated_session()
-            logger.info("Google authentication successful (Bearer session ready)")
+            self.google_cookies = google_manager.get_authenticated_cookies()
+            logger.info(
+                f"Captured {len(self.google_cookies)} Google session cookies."
+            )
         except Exception as e:
             logger.error(f"Google authentication failed: {e}")
             raise
-
-    def _get_google_secrets(self):
-        """Extract Google auth secrets stamped onto cfg by ingest.py."""
-        if hasattr(self.cfg.website_crawler, 'google_credentials_file'):
-            return {
-                'credentials_file': self.cfg.website_crawler.google_credentials_file,
-            }
-        raise Exception(
-            "Google authentication requires 'GOOGLE_CREDENTIALS_FILE' in secrets.toml"
-        )
-
-    def _get_scrapy_google_cookies(self):
-        """Capture browser session cookies for sites.google.com via Playwright
-        + persisted storage_state. Returns a {name: value} dict for Scrapy."""
-        google_config = self.cfg.website_crawler.get("google_auth")
-        if not google_config:
-            return None
-
-        try:
-            secrets_dict = self._get_google_secrets()
-            google_manager = GoogleAuthManager(google_config, secrets_dict)
-            return google_manager.get_authenticated_cookies()
-        except Exception as e:
-            logger.error(f"Failed to get Google cookies: {e}")
-            return None
 
     def _get_scrapy_saml_cookies(self):
         """
@@ -272,33 +320,13 @@ class WebsiteCrawler(Crawler):
         self._remove_old_content_if_needed(urls_to_crawl)
 
     def _configure_indexer_session(self):
-        """Configure indexer to use SAML and/or Google authenticated sessions."""
-        # Attach SAML session if present.
-        if self.saml_session and hasattr(self.indexer, 'session'):
-            self.indexer.session = self.saml_session
-            logger.info("Configured indexer to use SAML authenticated session")
-        elif self.google_session and hasattr(self.indexer, 'session'):
-            # Bearer-token Session is useful for Drive/Sites API calls, not for
-            # sites.google.com page content (those need browser cookies — see
-            # `_get_scrapy_google_cookies`). Only attach if SAML did not.
-            self.indexer.session = self.google_session
-            logger.info("Configured indexer to use Google Bearer-token session")
-
-        # Override web extractor's context creation to inject any auth cookies.
-        if self.saml_session or self.google_session:
-            self.indexer._init_processors()
-
-            if hasattr(self.indexer, 'web_extractor') and self.indexer.web_extractor:
-                original_new_context = self.indexer.web_extractor.browser.new_context
-
-                def new_context_with_auth(*args, **kwargs):
-                    context = original_new_context(*args, **kwargs)
-                    if self.saml_session:
-                        self._transfer_session_cookies_to_context(context, self.saml_session)
-                    return context
-
-                self.indexer.web_extractor.browser.new_context = new_context_with_auth
-                logger.info("Configured web extractor to use authenticated cookies")
+        """Propagate SAML session and/or Google cookies to the indexer's
+        `requests.Session` and Playwright `web_extractor`."""
+        _apply_auth_to_indexer(
+            self.indexer,
+            saml_session=self.saml_session,
+            google_cookies=self.google_cookies,
+        )
 
     def _discover_urls(self) -> list:
         """
@@ -331,11 +359,10 @@ class WebsiteCrawler(Crawler):
                 crawl_method = "internal"
 
         if crawl_method == "scrapy" and self.cfg.website_crawler.get("google_auth"):
-            logger.info("Google auth detected with Scrapy - loading persisted Google session cookies")
-            google_cookies = self._get_scrapy_google_cookies()
-            if google_cookies:
-                scrapy_cookies.update(google_cookies)
-                logger.info(f"Loaded {len(google_cookies)} Google session cookies")
+            logger.info("Google auth detected with Scrapy - forwarding captured session cookies")
+            if self.google_cookies:
+                scrapy_cookies.update(self.google_cookies)
+                logger.info(f"Loaded {len(self.google_cookies)} Google session cookies")
             else:
                 # Google cookies are required to crawl sites.google.com. Without
                 # them, every Scrapy request 302s into accounts.google.com and we
@@ -389,10 +416,12 @@ class WebsiteCrawler(Crawler):
             
             # Get URLs based on pages_source method
             if pages_source == "sitemap":
-                # Pass SAML session for authenticated sitemap access
-                urls = sitemap_to_urls(homepage, session=self.saml_session)
+                # `indexer.session` carries both SAML and Google cookies after
+                # `_configure_indexer_session` has run, so sitemap fetches work
+                # against authenticated origins regardless of which auth is set.
+                urls = sitemap_to_urls(homepage, session=self.indexer.session)
                 urls = [
-                    url for url in urls 
+                    url for url in urls
                     if url.startswith('http') and url_matches_patterns(url, self.pos_patterns, self.neg_patterns)
                 ]
             elif pages_source == "crawl":
@@ -505,8 +534,10 @@ class WebsiteCrawler(Crawler):
             results = list(pool.map(lambda a, u: a.process.remote(u, source=source), batch))
             if self.tracker:
                 for url, result in zip(batch, results):
-                    if result == 0:
+                    if result == PageCrawlWorker.RESULT_INDEXED:
                         self.tracker.track_indexed(url, url=url)
+                    elif result == PageCrawlWorker.RESULT_AUTH_REQUIRED:
+                        self.tracker.track_auth_required(url, url=url)
                     else:
                         self.tracker.track_failed(url, url=url)
             logger.info(f"Processed {min(batch_start + batch_size, len(urls))}/{len(urls)} URLs")
@@ -539,8 +570,10 @@ class WebsiteCrawler(Crawler):
                 logger.info(f"Crawling URL number {inx+1} out of {len(urls)}")
             result = crawl_worker.process(url, source=source)
             if self.tracker:
-                if result == 0:
+                if result == PageCrawlWorker.RESULT_INDEXED:
                     self.tracker.track_indexed(url, url=url)
+                elif result == PageCrawlWorker.RESULT_AUTH_REQUIRED:
+                    self.tracker.track_auth_required(url, url=url)
                 else:
                     self.tracker.track_failed(url, url=url)
         # Cleanup worker
@@ -556,10 +589,18 @@ class WebsiteCrawler(Crawler):
             return
         
         existing_docs = self.indexer._list_docs()
-        docs_to_remove = [t for t in existing_docs if t['url'] and t['url'] not in crawled_urls]
+        # Normalize both sides: the indexer stores metadata['url'] after
+        # normalize_url_for_metadata (URL-decoded), but crawled_urls comes
+        # straight from URL discovery and may still be percent-encoded.
+        # Without this, encoded discovery URLs would never match decoded
+        # stored URLs and would be flagged for deletion every crawl.
+        crawled_set = {normalize_url_for_metadata(u) for u in crawled_urls if u}
+        docs_to_remove = [
+            t for t in existing_docs
+            if t['url'] and normalize_url_for_metadata(t['url']) not in crawled_set
+        ]
         for doc in docs_to_remove:
-            if doc['url']:
-                self.indexer.delete_doc(doc['id'])
+            self.indexer.delete_doc(doc['id'])
         logger.info(f"Removed {len(docs_to_remove)} docs that are not included in the crawl but are in the corpus.")
         
         if self.cfg.website_crawler.get("crawl_report", False):

--- a/crawlers/website_crawler.py
+++ b/crawlers/website_crawler.py
@@ -154,11 +154,18 @@ class PageCrawlWorker(object):
                 auth_manager = SAMLAuthManager(config=self.saml_config, secrets=saml_secrets)
                 self.session = auth_manager.get_authenticated_session()
                 logging.info(f"[Worker {worker_pid}] SAML authentication successful.")
-                
-                # Assign the authenticated session to the indexer
-                self.indexer.session = self.session
-                logging.info(f"[Worker {worker_pid}] Authenticated session assigned to indexer.")
-                
+
+                # Wire SAML into both requests.Session and Playwright web_extractor
+                # via the shared helper. A bare `indexer.session = self.session`
+                # would leave `skip_static_prefetch` off, so the unauthenticated
+                # static prefetch in `WebContentExtractor.fetch_page_contents`
+                # would follow redirects to the IdP and short-circuit the
+                # authenticated browser path before it ran.
+                _apply_auth_to_indexer(self.indexer, saml_session=self.session)
+                logging.info(
+                    f"[Worker {worker_pid}] SAML session wired into indexer (requests + Playwright)."
+                )
+
             except Exception as e:
                 logging.error(f"[Worker {worker_pid}] Fatal SAML authentication failure: {e}")
                 raise

--- a/docs/GOOGLE_AUTHENTICATION.md
+++ b/docs/GOOGLE_AUTHENTICATION.md
@@ -1,0 +1,228 @@
+# Google Authentication for Website Crawler
+
+This document explains how to crawl private Google Sites (and other Google-protected
+URLs) with `vectara-ingest`'s website crawler. It is the Google counterpart to
+[`SAML_AUTHENTICATION.md`](./SAML_AUTHENTICATION.md) and is independent of it —
+you can enable Google auth, SAML auth, both, or neither.
+
+## When to use this
+
+Reach for `google_auth` when an anonymous fetch of your start URL gets 302-redirected
+to `https://accounts.google.com/ServiceLogin?...`. Typical cases:
+
+- Private Google Sites at `https://sites.google.com/d/<id>/p/<page>/edit`
+- Workspace-internal sites at `https://sites.google.com/<your-domain>/...`
+- Drive-hosted content that needs a signed-in browser session
+
+If your start URL is public but Google is rate-limiting / bot-checking, this is
+not the right tool — set a User-Agent or back off instead.
+
+## How it works (read this first)
+
+A Google service-account OAuth bearer token is **not** accepted by
+`sites.google.com` content URLs. Those URLs require browser session cookies — the
+same ones a real browser gets after `accounts.google.com/ServiceLogin`. There is
+no Google API that converts an SA token directly into those cookies.
+
+The crawler bridges the gap with Playwright `storage_state`:
+
+1. You run `crawlers/auth/google_bootstrap.py` once on a desktop machine. A real
+   Chromium window opens; you sign in to Google (including 2FA / SSO / account
+   chooser). When the browser lands on `sites.google.com`, the script writes the
+   resulting cookies + localStorage to a JSON file.
+2. You mount that JSON file into the crawler container at the path you set in
+   `google_auth.storage_state_path`.
+3. On each crawl, the crawler opens a headless Chromium with that state, captures
+   the live `.google.com` cookies, and hands them to Scrapy / the indexer.
+
+When the stored session expires (Workspace SSO usually expires sessions every few
+weeks), the crawler fails fast with a message telling you to re-run the bootstrap.
+There is no silent renewal.
+
+## Auth modes
+
+The `google_auth.mode` setting controls *which credential* the crawler binds to
+for any API-style calls (Drive / Sites APIs). Both modes use the same Playwright
+`storage_state` flow for `sites.google.com` content.
+
+### `oauth_user` (recommended, no Workspace admin needed)
+
+A regular Google account does a one-time OAuth consent. The resulting token JSON
+file is the credential. Same shape used by `gdrive_crawler`'s
+[`gdrive-oauth-setup.md`](./gdrive-oauth-setup.md).
+
+Pick this when:
+- You do not have Google Workspace admin access.
+- The crawler runs as a specific person (e.g. you).
+
+### `service_account` (Workspace orgs only)
+
+A Workspace service account with domain-wide delegation impersonates
+`delegated_user`. Workspace admin must grant DWD to the SA on the required
+scopes.
+
+Pick this when:
+- You have Workspace admin and want crawls to run as a dedicated service identity.
+- Multiple sites need to be crawled and you want predictable, shared credentials.
+
+Even with `service_account`, you still need the one-time `storage_state` capture
+(the SA itself cannot mint browser cookies — see "How it works" above).
+
+## Configuration
+
+### 1. YAML
+
+```yaml
+website_crawler:
+  urls:
+    - "https://sites.google.com/your-domain.com/internal-portal"
+  crawl_method: "scrapy"
+
+  google_auth:
+    mode: "oauth_user"             # or "service_account"
+    delegated_user: "you@your-domain.com"   # required only for service_account
+    scopes:                        # optional, sensible defaults applied
+      - "openid"
+      - "email"
+      - "https://www.googleapis.com/auth/userinfo.profile"
+    storage_state_path: "/home/vectara/env/google_storage_state.json"
+```
+
+Fields:
+
+- `mode` (required): `"oauth_user"` or `"service_account"`.
+- `delegated_user` (required for `service_account`): the Workspace user the SA
+  impersonates.
+- `scopes` (optional): OAuth scopes. Defaults to
+  `["openid", "email", "https://www.googleapis.com/auth/userinfo.profile"]`.
+- `storage_state_path` (required for any `sites.google.com` crawling): path to
+  the JSON file produced by `google_bootstrap.py`. The crawler will refuse to
+  start `sites.google.com` crawls without this file present.
+
+### 2. Secrets
+
+In `secrets.toml`:
+
+```toml
+[default]
+GOOGLE_CREDENTIALS_FILE = "/home/vectara/env/google_credentials.json"
+# Optional — sets google_auth.storage_state_path if not provided in YAML:
+GOOGLE_STORAGE_STATE_FILE = "/home/vectara/env/google_storage_state.json"
+```
+
+`GOOGLE_CREDENTIALS_FILE` is:
+- For `oauth_user`: the OAuth token JSON (with `token`, `refresh_token`, `token_uri`,
+  `client_id`, `client_secret`, `scopes`). Same format as
+  [`gdrive-oauth-setup.md`](./gdrive-oauth-setup.md) produces.
+- For `service_account`: the SA key JSON downloaded from Google Cloud Console.
+
+Note: this file is intentionally separate from `gdrive_crawler`'s hardcoded
+`/home/vectara/env/credentials.json` — both can coexist with different SAs.
+
+## One-time bootstrap
+
+Run on a machine with a display (NOT in the Docker container):
+
+```bash
+pip install playwright
+playwright install chromium
+
+python -m crawlers.auth.google_bootstrap \
+  --output ./google_storage_state.json
+```
+
+What you'll see:
+
+1. A Chromium window opens to `https://sites.google.com`.
+2. Sign in. Complete 2FA / SSO / account chooser as needed.
+3. When the URL stabilizes on `sites.google.com` (and is no longer on
+   `accounts.google.com`), the script writes `google_storage_state.json` and exits.
+
+Then mount that file into your container at the path you set in
+`google_auth.storage_state_path`.
+
+Options:
+
+- `--start-url <url>`: open a different starting URL (default `https://sites.google.com`).
+- `--success-url-contains <substring>`: customise the success-detection check
+  (default `sites.google.com`).
+- `--timeout-seconds <n>`: how long to wait for sign-in (default 300).
+
+## Setting up `oauth_user` credentials
+
+Follow [`gdrive-oauth-setup.md`](./gdrive-oauth-setup.md) — the same OAuth client
+and token JSON work for Google auth in the website crawler.
+
+You need at minimum the `openid` and `email` scopes; the userinfo profile scope
+is recommended. The `drive.readonly` scope is not required for `sites.google.com`
+crawling.
+
+## Setting up `service_account` credentials
+
+In Google Cloud Console:
+
+1. Create or select a Workspace-linked GCP project.
+2. Create a service account; download its JSON key.
+3. In Google Workspace Admin Console (admin.google.com), under
+   **Security → Access and data control → API controls → Domain-wide delegation**,
+   add the SA's client ID with the required scopes (`openid`, `email`, plus any
+   API scopes you need).
+
+The SA cannot crawl `sites.google.com` content on its own — you still need the
+one-time `storage_state` capture as a Workspace user (typically the
+`delegated_user`).
+
+## Running a crawl
+
+```bash
+python ingest.py config/google-site-example.yaml default
+```
+
+Expected log lines:
+
+```
+Google authentication configured, initializing...
+Google authentication successful (Bearer session ready)
+Google auth detected with Scrapy - loading persisted Google session cookies
+Loaded N Google session cookies
+```
+
+If you instead see:
+
+```
+Stored Google session has expired (landed on https://accounts.google.com/...).
+Re-run `python -m crawlers.auth.google_bootstrap --output ...`.
+```
+
+— re-run the bootstrap and re-mount the new file.
+
+## Combining with SAML
+
+The `google_auth` and `saml_auth` blocks are independent. If a single crawl
+needs both (for example, a Workspace SSO domain that fronts internal apps with a
+separate SAML flow), set both blocks. The crawler obtains cookies from each and
+merges them before passing to Scrapy.
+
+## Troubleshooting
+
+- **`LinkSpider finished. Found 0 unique URLs.`** — anonymous fetches are
+  bouncing off `accounts.google.com`. Check that `google_auth.storage_state_path`
+  exists and is mounted into the container.
+- **`Stored Google session has expired ...`** — re-run `google_bootstrap.py`.
+  Workspace SSO typically forces re-auth every 2–4 weeks.
+- **`google_auth requires 'credentials_file' in secrets`** — `GOOGLE_CREDENTIALS_FILE`
+  is missing from `secrets.toml` (or under the wrong profile). It is read in
+  `ingest.py` and stamped onto `cfg.website_crawler.google_credentials_file`.
+- **`google_auth mode 'service_account' requires 'delegated_user'`** — set the
+  email of the Workspace user the SA should impersonate in YAML.
+- **`Playwright is not available`** — install Playwright and download Chromium:
+  `pip install playwright && playwright install chromium`.
+
+## Limitations
+
+- 2FA / SSO / BeyondCorp: handled by the one-time interactive bootstrap. The
+  crawler itself runs headless.
+- Session lifetime: tied to Google / Workspace policy. Plan to re-run the
+  bootstrap when it expires; the crawler will tell you when.
+- Cookie scope: only `.google.com` cookies are captured. The crawler will not
+  inject Google session cookies into requests for unrelated domains.

--- a/docs/GOOGLE_AUTHENTICATION.md
+++ b/docs/GOOGLE_AUTHENTICATION.md
@@ -142,15 +142,21 @@ Run on a machine with a display (NOT in the Docker container):
 
 ```bash
 pip install playwright
-playwright install chromium
+playwright install chrome
 
 python -m crawlers.auth.google_bootstrap \
   --output ./google_storage_state.json
 ```
 
+We launch installed Google Chrome (not Playwright's bundled Chromium) because
+Chromium is reliably flagged by Cloudflare and Google bot detection — the
+sign-in flow ends up stuck on an unsolvable CAPTCHA. A persistent Chrome
+profile is also kept across runs (default `~/.cache/vectara-ingest/google_bootstrap_profile`)
+so subsequent runs look like a returning user.
+
 What you'll see:
 
-1. A Chromium window opens to `https://sites.google.com`.
+1. A Chrome window opens to `https://sites.google.com`.
 2. Sign in. Complete 2FA / SSO / account chooser as needed.
 3. When the URL stabilizes on `sites.google.com` (and is no longer on
    `accounts.google.com`), the script writes `google_storage_state.json` and exits.
@@ -164,6 +170,10 @@ Options:
 - `--success-url-contains <substring>`: customise the success-detection check
   (default `sites.google.com`).
 - `--timeout-seconds <n>`: how long to wait for sign-in (default 300).
+- `--profile-dir <path>`: persistent Chrome profile directory. Delete it to
+  start from a clean slate.
+- `--channel <name>`: Playwright browser channel (default `chrome`). Pass an
+  empty string to fall back to bundled Chromium.
 
 ## Setting up `oauth_user` credentials
 

--- a/docs/GOOGLE_AUTHENTICATION.md
+++ b/docs/GOOGLE_AUTHENTICATION.md
@@ -76,7 +76,7 @@ Even with `service_account`, you still need the one-time `storage_state` capture
 website_crawler:
   urls:
     - "https://sites.google.com/your-domain.com/internal-portal"
-  crawl_method: "scrapy"
+  crawl_method: "scrapy"           # "scrapy" or "internal" — both honor google_auth
 
   google_auth:
     mode: "oauth_user"             # or "service_account"
@@ -85,7 +85,7 @@ website_crawler:
       - "openid"
       - "email"
       - "https://www.googleapis.com/auth/userinfo.profile"
-    storage_state_path: "/home/vectara/env/google_storage_state.json"
+    storage_state_path: "~/.config/vectara/google_storage_state.json"
 ```
 
 Fields:
@@ -95,20 +95,37 @@ Fields:
   impersonates.
 - `scopes` (optional): OAuth scopes. Defaults to
   `["openid", "email", "https://www.googleapis.com/auth/userinfo.profile"]`.
-- `storage_state_path` (required for any `sites.google.com` crawling): path to
-  the JSON file produced by `google_bootstrap.py`. The crawler will refuse to
-  start `sites.google.com` crawls without this file present.
+- `storage_state_path` (required for any `sites.google.com` crawling): **host**
+  path to the JSON file produced by `google_bootstrap.py`. When you launch via
+  `run.sh`, this file is auto-mounted into the container at
+  `/home/vectara/env/google_storage_state.json`; the crawler resolves to the
+  container path automatically. When you run `python ingest.py` directly (no
+  Docker), the file is read from this path on the local filesystem. The crawler
+  will refuse to start `sites.google.com` crawls without this file present.
 
-### 2. Secrets
+`crawl_method` choice: both `scrapy` and `internal` honor `google_auth`. The
+captured session cookies are injected into the indexer's HTTP session and into
+the Playwright `web_extractor` regardless of discovery method. Pick `scrapy`
+for faster discovery on large sites; pick `internal` (the default) when you
+want full Playwright-rendered fidelity end-to-end.
 
-In `secrets.toml`:
+### 2. Secrets (optional)
+
+`GOOGLE_CREDENTIALS_FILE` is only consumed when the crawler calls
+`GoogleAuthManager.get_authenticated_session()` for Google API access (Drive,
+Sites APIs). Plain `sites.google.com` page crawling does not call any Google
+API and does not need this secret — `storage_state_path` is enough.
+
+If you do want API access, add it to `secrets.toml`:
 
 ```toml
 [default]
 GOOGLE_CREDENTIALS_FILE = "/home/vectara/env/google_credentials.json"
-# Optional — sets google_auth.storage_state_path if not provided in YAML:
-GOOGLE_STORAGE_STATE_FILE = "/home/vectara/env/google_storage_state.json"
 ```
+
+`ingest.py` reads this value and stamps it onto `cfg.website_crawler.google_credentials_file`
+at runtime — that is why the field is **not** placed inside the `google_auth:`
+block in YAML.
 
 `GOOGLE_CREDENTIALS_FILE` is:
 - For `oauth_user`: the OAuth token JSON (with `token`, `refresh_token`, `token_uri`,
@@ -181,10 +198,10 @@ python ingest.py config/google-site-example.yaml default
 Expected log lines:
 
 ```
-Google authentication configured, initializing...
-Google authentication successful (Bearer session ready)
-Google auth detected with Scrapy - loading persisted Google session cookies
-Loaded N Google session cookies
+Google authentication configured, capturing storage_state cookies...
+Captured N Google session cookies.
+Merged N Google session cookies into indexer session
+Configured web extractor to inject authenticated cookies
 ```
 
 If you instead see:
@@ -210,9 +227,11 @@ merges them before passing to Scrapy.
   exists and is mounted into the container.
 - **`Stored Google session has expired ...`** — re-run `google_bootstrap.py`.
   Workspace SSO typically forces re-auth every 2–4 weeks.
-- **`google_auth requires 'credentials_file' in secrets`** — `GOOGLE_CREDENTIALS_FILE`
-  is missing from `secrets.toml` (or under the wrong profile). It is read in
-  `ingest.py` and stamped onto `cfg.website_crawler.google_credentials_file`.
+- **`google_auth requires 'credentials_file' in secrets ...`** — fires only
+  when something asks for Google API credentials (e.g. a custom call to
+  `GoogleAuthManager.get_authenticated_session()`). For plain `sites.google.com`
+  crawling this error should never fire; if it does, you have third-party code
+  calling the API path — set `GOOGLE_CREDENTIALS_FILE` in `secrets.toml`.
 - **`google_auth mode 'service_account' requires 'delegated_user'`** — set the
   email of the Workspace user the SA should impersonate in YAML.
 - **`Playwright is not available`** — install Playwright and download Chromium:

--- a/ingest.py
+++ b/ingest.py
@@ -218,6 +218,12 @@ def update_environment(cfg: DictConfig, source: str, env_dict) -> None:
         if k == 'SAML_PASSWORD':
             update_omega_conf(cfg, reason, f'website_crawler.{k.lower()}', v)
             continue
+        if k == 'GOOGLE_CREDENTIALS_FILE':
+            update_omega_conf(cfg, reason, f'website_crawler.{k.lower()}', v)
+            continue
+        if k == 'GOOGLE_STORAGE_STATE_FILE':
+            update_omega_conf(cfg, reason, f'website_crawler.{k.lower()}', v)
+            continue
         if k.startswith('aws_'):
             update_omega_conf(cfg, reason, f's3_crawler.{k.lower()}', v)
             continue

--- a/ingest.py
+++ b/ingest.py
@@ -221,9 +221,6 @@ def update_environment(cfg: DictConfig, source: str, env_dict) -> None:
         if k == 'GOOGLE_CREDENTIALS_FILE':
             update_omega_conf(cfg, reason, f'website_crawler.{k.lower()}', v)
             continue
-        if k == 'GOOGLE_STORAGE_STATE_FILE':
-            update_omega_conf(cfg, reason, f'website_crawler.{k.lower()}', v)
-            continue
         if k.startswith('aws_'):
             update_omega_conf(cfg, reason, f's3_crawler.{k.lower()}', v)
             continue
@@ -406,9 +403,10 @@ def run_ingest(config_file: str, profile: str, secrets_path: Optional[str] = Non
             stats = tracker.get_stats()
             if stats:
                 logger.info(
-                    "Crawl stats: total=%s indexed=%s failed=%s skipped=%s",
+                    "Crawl stats: total=%s indexed=%s failed=%s skipped=%s auth_required=%s",
                     stats["total_docs"], stats["indexed_docs"],
                     stats["failed_docs"], stats["skipped_docs"],
+                    stats.get("auth_required_docs", 0),
                 )
             tracker.close()
         crawler.tracker = None

--- a/run.sh
+++ b/run.sh
@@ -239,6 +239,28 @@ if [[ "$crawler_type" == "gdrive" ]]; then
   DOCKER_RUN_ARGS+=(-v "$(realpath "$credentials_path"):/home/vectara/env/credentials.json:rw")
 fi
 
+# Mount Google storage_state file for the website crawler's google_auth flow.
+# Mirrors the gdrive credentials.json pattern: user supplies the host path in
+# YAML; we mount it to a fixed in-container path that `GoogleAuthManager`
+# resolves to automatically.
+if [[ "$crawler_type" == "website" ]]; then
+  storage_state_path=$(read_yaml_nested "data.get('website_crawler', {}).get('google_auth', {}).get('storage_state_path', '')")
+
+  if [[ -n "$storage_state_path" ]]; then
+    # Expand tilde to home directory
+    storage_state_path="${storage_state_path/#\~/$HOME}"
+
+    if [[ ! -f "$storage_state_path" ]]; then
+      echo "Error: Google storage_state file not found at '$storage_state_path'" >&2
+      echo "Run \`python -m crawlers.auth.google_bootstrap --output $storage_state_path\` to capture it." >&2
+      exit "$ERR_MISSING_GDRIVE_CREDS"
+    fi
+
+    DOCKER_RUN_ARGS+=(-v "$(realpath "$storage_state_path"):/home/vectara/env/google_storage_state.json:ro")
+    echo "Mounting Google storage_state to: /home/vectara/env/google_storage_state.json"
+  fi
+fi
+
 if [[ "$crawler_type" == "box" ]]; then
   auth_type=$(read_yaml_nested "data.get('box_crawler', {}).get('auth_type', 'jwt')")
 

--- a/run.sh
+++ b/run.sh
@@ -16,6 +16,10 @@ readonly ERR_CRAWLER_COPY_FAILED=8
 readonly ERR_CUSTOM_CRAWLER_NOT_FOUND=9
 readonly ERR_CRAWLER_FILENAME_MISMATCH=10
 readonly ERR_CRAWLER_NOT_FOUND=11
+# Generic "auth/credentials file referenced by config does not exist" for
+# crawlers other than gdrive. Keeping ERR_MISSING_GDRIVE_CREDS=7 with its
+# original meaning preserves any existing CI/orchestration that keys on 7.
+readonly ERR_MISSING_AUTH_FILE=12
 
 if [[ $# -lt 2 ]]; then
   echo "Missing arguments." >&2
@@ -253,7 +257,7 @@ if [[ "$crawler_type" == "website" ]]; then
     if [[ ! -f "$storage_state_path" ]]; then
       echo "Error: Google storage_state file not found at '$storage_state_path'" >&2
       echo "Run \`python -m crawlers.auth.google_bootstrap --output $storage_state_path\` to capture it." >&2
-      exit "$ERR_MISSING_GDRIVE_CREDS"
+      exit "$ERR_MISSING_AUTH_FILE"
     fi
 
     DOCKER_RUN_ARGS+=(-v "$(realpath "$storage_state_path"):/home/vectara/env/google_storage_state.json:ro")
@@ -275,7 +279,7 @@ if [[ "$crawler_type" == "box" ]]; then
       if [[ ! -f "$jwt_config_path" ]]; then
         echo "Error: Box JWT config file not found at '$jwt_config_path'" >&2
         echo "Please ensure the jwt_config_file path in your config is correct" >&2
-        exit "$ERR_MISSING_GDRIVE_CREDS"
+        exit "$ERR_MISSING_AUTH_FILE"
       fi
 
       DOCKER_RUN_ARGS+=(-v "$(realpath "$jwt_config_path"):/home/vectara/env/box_config.json:ro")
@@ -292,7 +296,7 @@ if [[ "$crawler_type" == "box" ]]; then
       if [[ ! -f "$oauth_creds_path" ]]; then
         echo "Error: Box OAuth credentials file not found at '$oauth_creds_path'" >&2
         echo "Please ensure the oauth_credentials_file path in your config is correct" >&2
-        exit "$ERR_MISSING_GDRIVE_CREDS"
+        exit "$ERR_MISSING_AUTH_FILE"
       fi
 
       DOCKER_RUN_ARGS+=(-v "$(realpath "$oauth_creds_path"):/home/vectara/env/box_oauth_credentials.json:ro")

--- a/tests/test_crawl_tracker.py
+++ b/tests/test_crawl_tracker.py
@@ -128,6 +128,35 @@ class TestCrawlTrackerTracking(unittest.TestCase):
         self.assertEqual(stats["skipped_docs"], 1)
         self.assertEqual(stats["total_docs"], 4)
 
+    def test_track_auth_required_is_distinct_from_failed(self):
+        # Auth-required URLs are a separate outcome from generic failures:
+        # the page wasn't broken, we just don't have access. The user needs
+        # this counted separately so they can decide whether to add auth.
+        self.tracker.track_auth_required(
+            "d1", url="https://sites.google.com/d/x/p/y/edit",
+            reason="redirected to identity-provider accounts.google.com",
+        )
+        self.tracker.track_failed("d2", error="500 internal server error")
+
+        stats = self.tracker.get_stats()
+        self.assertEqual(stats["auth_required_docs"], 1)
+        self.assertEqual(stats["failed_docs"], 1)
+        self.assertEqual(stats["total_docs"], 2)
+        # An auth_required doc must not also be counted as failed/indexed.
+        self.assertNotIn("d1", self.tracker.get_failed_ids())
+        self.assertNotIn("d1", self.tracker.get_indexed_ids())
+
+    def test_auth_required_retry_succeeds_decrements_counter(self):
+        # If the user later configures auth and the URL is re-crawled
+        # successfully, the auth_required counter must drop and indexed
+        # must rise — same per-status decrement logic as failed→indexed.
+        self.tracker.track_auth_required("d1", url="https://x.example/private")
+        self.assertEqual(self.tracker.get_stats()["auth_required_docs"], 1)
+        self.tracker.track_indexed("d1", url="https://x.example/private")
+        stats = self.tracker.get_stats()
+        self.assertEqual(stats["auth_required_docs"], 0)
+        self.assertEqual(stats["indexed_docs"], 1)
+
 
 class TestCrawlTrackerShutdown(unittest.TestCase):
     """Test graceful shutdown mechanics."""
@@ -345,6 +374,57 @@ class TestCrawlerShutdownWithoutTracker(unittest.TestCase):
                 crawler.check_shutdown()
 
             tracker.close()
+
+
+class TestCrawlTrackerMigration(unittest.TestCase):
+    """Existing pre-auth_required DBs must upgrade in place on open."""
+
+    def test_old_schema_is_migrated(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "crawl_tracking.db")
+            # Hand-create the *pre-migration* schema and seed a few rows,
+            # mirroring what older versions of vectara-ingest left on disk.
+            conn = sqlite3.connect(db_path)
+            conn.executescript("""
+                CREATE TABLE documents (
+                    doc_id TEXT NOT NULL,
+                    crawler_type TEXT NOT NULL,
+                    status TEXT NOT NULL CHECK(status IN ('indexed', 'failed', 'skipped')),
+                    url TEXT, title TEXT, error TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (doc_id, crawler_type)
+                );
+                CREATE TABLE crawl_state (
+                    crawler_type TEXT PRIMARY KEY,
+                    status TEXT NOT NULL DEFAULT 'running',
+                    started_at TEXT,
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    total_docs INTEGER DEFAULT 0,
+                    indexed_docs INTEGER DEFAULT 0,
+                    failed_docs INTEGER DEFAULT 0,
+                    skipped_docs INTEGER DEFAULT 0
+                );
+                INSERT INTO crawl_state(crawler_type, status, total_docs, indexed_docs)
+                    VALUES ('website', 'running', 1, 1);
+                INSERT INTO documents(doc_id, crawler_type, status, url, title)
+                    VALUES ('legacy', 'website', 'indexed', 'http://x', 't');
+            """)
+            conn.commit()
+            conn.close()
+
+            # Opening the tracker should migrate without raising.
+            tracker = CrawlTracker(db_path, "website")
+            try:
+                # The legacy row survived migration.
+                self.assertTrue(tracker.is_indexed("legacy"))
+                # New status now works on the migrated CHECK constraint.
+                tracker.track_auth_required("auth1", url="http://private")
+                stats = tracker.get_stats()
+                self.assertEqual(stats["auth_required_docs"], 1)
+                self.assertEqual(stats["indexed_docs"], 1)
+            finally:
+                tracker.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_google_auth_manager.py
+++ b/tests/test_google_auth_manager.py
@@ -270,9 +270,17 @@ def test_get_authenticated_cookies_uses_storage_state_when_present(tmp_path):
     secrets = {"credentials_file": "/tmp/oauth.json"}
 
     cookies = [
-        {"name": "SID", "value": "sid-val", "domain": ".google.com"},
-        {"name": "SSID", "value": "ssid-val", "domain": ".google.com"},
-        {"name": "unrelated", "value": "x", "domain": "example.com"},
+        {"name": "SID", "value": "sid-val", "domain": ".google.com",
+         "path": "/", "secure": True, "httpOnly": True, "sameSite": "Lax"},
+        {"name": "__Host-1PLSID", "value": "psid-val",
+         "domain": "accounts.google.com", "path": "/", "secure": True,
+         "httpOnly": True, "sameSite": "Lax"},
+        {"name": "OSID", "value": "osid-val",
+         "domain": "sites.google.com", "path": "/", "secure": True},
+        {"name": "unrelated", "value": "x", "domain": "example.com",
+         "path": "/", "secure": False},
+        {"name": "rip", "value": "y", "domain": ".rippling.com",
+         "path": "/", "secure": True},
     ]
     pw_factory, context, page = _build_playwright_chain(cookies)
 
@@ -280,16 +288,31 @@ def test_get_authenticated_cookies_uses_storage_state_when_present(tmp_path):
         mgr = google_manager.GoogleAuthManager(config, secrets)
         result = mgr.get_authenticated_cookies()
 
-    # Playwright was asked to load the existing storage state
-    new_context_kwargs = context.new_context.call_args if hasattr(context, "call_args") else None
-    # The browser.new_context call (not context.new_context) should have received storage_state
+    # The browser.new_context call should have received storage_state
     chromium = pw_factory.start.return_value.chromium
     browser = chromium.launch.return_value
     _, kwargs = browser.new_context.call_args
     assert kwargs.get("storage_state") == str(storage_file)
 
-    # Only *.google.com cookies are returned, as a {name: value} dict
-    assert result == {"SID": "sid-val", "SSID": "ssid-val"}
+    # New contract: list of dicts with attributes preserved. Only Google-family
+    # cookies (.google.com, accounts.google.com, sites.google.com) survive —
+    # the example.com and .rippling.com entries are filtered out so they
+    # don't leak cross-domain when Scrapy follows redirects.
+    assert isinstance(result, list)
+    names = {c["name"]: c for c in result}
+    assert set(names) == {"SID", "__Host-1PLSID", "OSID"}
+
+    sid = names["SID"]
+    assert sid["value"] == "sid-val"
+    assert sid["domain"] == ".google.com"
+    assert sid["path"] == "/"
+    assert sid["secure"] is True
+
+    host_cookie = names["__Host-1PLSID"]
+    # __Host-* cookies must keep their host-scoped domain so Scrapy doesn't
+    # leak them to sites.google.com on a redirect.
+    assert host_cookie["domain"] == "accounts.google.com"
+    assert host_cookie["secure"] is True
 
 
 def test_get_authenticated_cookies_raises_when_landing_on_login_page(tmp_path):

--- a/tests/test_google_auth_manager.py
+++ b/tests/test_google_auth_manager.py
@@ -7,7 +7,6 @@ google.oauth2) are mocked so tests are hermetic.
 
 import json
 import sys
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 # Stub heavy native deps that some sibling modules transitively import.
@@ -51,14 +50,31 @@ def test_init_rejects_unknown_mode():
         GoogleAuthManager(config, secrets)
 
 
-def test_init_requires_credentials_file_in_secrets():
+def test_init_does_not_require_credentials_file_when_only_cookies_needed():
+    """Crawls that only consume sites.google.com cookies (via storage_state)
+    must work without ever providing GOOGLE_CREDENTIALS_FILE — that secret
+    only matters for API-style Bearer calls, which a content crawl doesn't
+    make."""
+    from crawlers.auth.google_manager import GoogleAuthManager
+
+    config = {"mode": "oauth_user", "storage_state_path": "/tmp/state.json"}
+    secrets = {}
+
+    mgr = GoogleAuthManager(config, secrets)
+    assert mgr.credentials_file is None
+
+
+def test_get_credentials_raises_when_credentials_file_missing():
+    """The credential check is deferred — but the moment a caller actually
+    asks for API credentials, the manager must complain loudly."""
     from crawlers.auth.google_manager import GoogleAuthManager
 
     config = {"mode": "oauth_user"}
     secrets = {}
 
-    with pytest.raises(ValueError, match="credentials_file"):
-        GoogleAuthManager(config, secrets)
+    mgr = GoogleAuthManager(config, secrets)
+    with pytest.raises(ValueError, match="GOOGLE_CREDENTIALS_FILE"):
+        mgr.get_credentials()
 
 
 def test_init_accepts_optional_storage_state_path():
@@ -72,6 +88,55 @@ def test_init_accepts_optional_storage_state_path():
 
     mgr = GoogleAuthManager(config, secrets)
     assert mgr.storage_state_path == "/tmp/state.json"
+
+
+def test_storage_state_path_uses_docker_mount_when_present(monkeypatch):
+    """Inside Docker, run.sh mounts the host file to a fixed container path.
+    When that fixed path exists, it wins over the YAML-supplied host path —
+    the YAML field is a host path, not a container path."""
+    from crawlers.auth import google_manager
+
+    real_exists = google_manager.os.path.exists
+
+    def fake_exists(p):
+        if p == google_manager.DOCKER_STORAGE_STATE_PATH:
+            return True
+        return real_exists(p)
+
+    monkeypatch.setattr(google_manager.os.path, "exists", fake_exists)
+
+    config = {
+        "mode": "oauth_user",
+        "storage_state_path": "/some/host/path/state.json",
+    }
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    mgr = google_manager.GoogleAuthManager(config, secrets)
+    assert mgr.storage_state_path == google_manager.DOCKER_STORAGE_STATE_PATH
+
+
+def test_storage_state_path_falls_back_to_config_path_when_no_docker_mount(monkeypatch):
+    """Running natively (or in Docker without the auto-mount), the YAML path
+    is used directly."""
+    from crawlers.auth import google_manager
+
+    real_exists = google_manager.os.path.exists
+
+    def fake_exists(p):
+        if p == google_manager.DOCKER_STORAGE_STATE_PATH:
+            return False
+        return real_exists(p)
+
+    monkeypatch.setattr(google_manager.os.path, "exists", fake_exists)
+
+    config = {
+        "mode": "oauth_user",
+        "storage_state_path": "/some/host/path/state.json",
+    }
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    mgr = google_manager.GoogleAuthManager(config, secrets)
+    assert mgr.storage_state_path == "/some/host/path/state.json"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_google_auth_manager.py
+++ b/tests/test_google_auth_manager.py
@@ -1,0 +1,278 @@
+"""Spec tests for GoogleAuthManager.
+
+Defines the contract for `crawlers/auth/google_manager.py` before the
+implementation lands. All external boundaries (Playwright, google.auth,
+google.oauth2) are mocked so tests are hermetic.
+"""
+
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# Stub heavy native deps that some sibling modules transitively import.
+for _mod in ["cairosvg", "whisper", "pdf2image"]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# __init__ validation
+# ---------------------------------------------------------------------------
+
+def test_init_service_account_mode_requires_delegated_user():
+    from crawlers.auth.google_manager import GoogleAuthManager
+
+    config = {"mode": "service_account"}
+    secrets = {"credentials_file": "/tmp/sa.json"}
+
+    with pytest.raises(ValueError, match="delegated_user"):
+        GoogleAuthManager(config, secrets)
+
+
+def test_init_oauth_user_mode_does_not_require_delegated_user():
+    from crawlers.auth.google_manager import GoogleAuthManager
+
+    config = {"mode": "oauth_user"}
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    mgr = GoogleAuthManager(config, secrets)
+    assert mgr.mode == "oauth_user"
+
+
+def test_init_rejects_unknown_mode():
+    from crawlers.auth.google_manager import GoogleAuthManager
+
+    config = {"mode": "magic"}
+    secrets = {"credentials_file": "/tmp/x.json"}
+
+    with pytest.raises(ValueError, match="mode"):
+        GoogleAuthManager(config, secrets)
+
+
+def test_init_requires_credentials_file_in_secrets():
+    from crawlers.auth.google_manager import GoogleAuthManager
+
+    config = {"mode": "oauth_user"}
+    secrets = {}
+
+    with pytest.raises(ValueError, match="credentials_file"):
+        GoogleAuthManager(config, secrets)
+
+
+def test_init_accepts_optional_storage_state_path():
+    from crawlers.auth.google_manager import GoogleAuthManager
+
+    config = {
+        "mode": "oauth_user",
+        "storage_state_path": "/tmp/state.json",
+    }
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    mgr = GoogleAuthManager(config, secrets)
+    assert mgr.storage_state_path == "/tmp/state.json"
+
+
+# ---------------------------------------------------------------------------
+# get_credentials
+# ---------------------------------------------------------------------------
+
+def test_get_credentials_service_account_delegates_to_gdrive_helper():
+    from crawlers.auth import google_manager
+
+    config = {
+        "mode": "service_account",
+        "delegated_user": "user@example.com",
+        "scopes": ["openid", "email"],
+    }
+    secrets = {"credentials_file": "/tmp/sa.json"}
+
+    fake_creds = MagicMock(name="fake_sa_creds")
+    with patch.object(google_manager, "get_credentials", return_value=fake_creds) as helper:
+        mgr = google_manager.GoogleAuthManager(config, secrets)
+        result = mgr.get_credentials()
+
+    helper.assert_called_once()
+    args, kwargs = helper.call_args
+    # delegated_user, credentials path, scopes are passed through
+    assert "user@example.com" in args or kwargs.get("delegated_user") == "user@example.com"
+    assert result is fake_creds
+
+
+def test_get_credentials_oauth_user_delegates_to_gdrive_helper():
+    from crawlers.auth import google_manager
+
+    config = {"mode": "oauth_user", "scopes": ["openid", "email"]}
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    fake_creds = MagicMock(name="fake_oauth_creds")
+    with patch.object(google_manager, "get_oauth_credentials", return_value=fake_creds) as helper:
+        mgr = google_manager.GoogleAuthManager(config, secrets)
+        result = mgr.get_credentials()
+
+    helper.assert_called_once()
+    args, kwargs = helper.call_args
+    assert "/tmp/oauth.json" in args or kwargs.get("credentials_file") == "/tmp/oauth.json"
+    assert result is fake_creds
+
+
+def test_default_scopes_include_openid_and_email():
+    from crawlers.auth import google_manager
+
+    config = {"mode": "oauth_user"}  # no scopes specified
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    captured_scopes = {}
+
+    def fake_oauth(credentials_file, scopes=None):
+        captured_scopes["scopes"] = scopes
+        return MagicMock()
+
+    with patch.object(google_manager, "get_oauth_credentials", side_effect=fake_oauth):
+        mgr = google_manager.GoogleAuthManager(config, secrets)
+        mgr.get_credentials()
+
+    assert "openid" in captured_scopes["scopes"]
+    assert "email" in captured_scopes["scopes"]
+
+
+# ---------------------------------------------------------------------------
+# get_authenticated_session
+# ---------------------------------------------------------------------------
+
+def test_get_authenticated_session_sets_bearer_header():
+    from crawlers.auth import google_manager
+
+    config = {"mode": "oauth_user"}
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    fake_creds = MagicMock()
+    fake_creds.token = "ya29.fake-access-token"
+    fake_creds.expired = False
+
+    with patch.object(google_manager, "get_oauth_credentials", return_value=fake_creds):
+        mgr = google_manager.GoogleAuthManager(config, secrets)
+        session = mgr.get_authenticated_session()
+
+    assert session.headers.get("Authorization") == "Bearer ya29.fake-access-token"
+
+
+# ---------------------------------------------------------------------------
+# get_authenticated_cookies — storage_state happy path
+# ---------------------------------------------------------------------------
+
+def _build_playwright_chain(cookies, final_url="https://sites.google.com/d/abc/p/xyz"):
+    """Build a nested-MagicMock Playwright chain that returns the given cookies.
+
+    Mirrors: sync_playwright().start() -> chromium.launch() -> new_context(...) -> new_page().
+    """
+    page = MagicMock(name="page")
+    page.url = final_url
+    page.goto = MagicMock()
+    page.content = MagicMock(return_value="<html><body>real site content</body></html>")
+    page.wait_for_load_state = MagicMock()
+
+    context = MagicMock(name="context")
+    context.new_page.return_value = page
+    context.cookies.return_value = cookies  # list of {name, value, domain, ...}
+
+    browser = MagicMock(name="browser")
+    browser.new_context.return_value = context
+
+    chromium = MagicMock(name="chromium")
+    chromium.launch.return_value = browser
+
+    pw_instance = MagicMock(name="pw_instance")
+    pw_instance.chromium = chromium
+
+    pw_factory = MagicMock(name="pw_factory")
+    pw_factory.start.return_value = pw_instance
+
+    return pw_factory, context, page
+
+
+def test_get_authenticated_cookies_uses_storage_state_when_present(tmp_path):
+    from crawlers.auth import google_manager
+
+    storage_file = tmp_path / "state.json"
+    storage_file.write_text(json.dumps({"cookies": [], "origins": []}))
+
+    config = {
+        "mode": "oauth_user",
+        "storage_state_path": str(storage_file),
+    }
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    cookies = [
+        {"name": "SID", "value": "sid-val", "domain": ".google.com"},
+        {"name": "SSID", "value": "ssid-val", "domain": ".google.com"},
+        {"name": "unrelated", "value": "x", "domain": "example.com"},
+    ]
+    pw_factory, context, page = _build_playwright_chain(cookies)
+
+    with patch.object(google_manager, "sync_playwright", return_value=pw_factory):
+        mgr = google_manager.GoogleAuthManager(config, secrets)
+        result = mgr.get_authenticated_cookies()
+
+    # Playwright was asked to load the existing storage state
+    new_context_kwargs = context.new_context.call_args if hasattr(context, "call_args") else None
+    # The browser.new_context call (not context.new_context) should have received storage_state
+    chromium = pw_factory.start.return_value.chromium
+    browser = chromium.launch.return_value
+    _, kwargs = browser.new_context.call_args
+    assert kwargs.get("storage_state") == str(storage_file)
+
+    # Only *.google.com cookies are returned, as a {name: value} dict
+    assert result == {"SID": "sid-val", "SSID": "ssid-val"}
+
+
+def test_get_authenticated_cookies_raises_when_landing_on_login_page(tmp_path):
+    """If after navigation the browser is sitting on accounts.google.com, the
+    stored state has expired and we cannot authenticate silently. The manager
+    should surface a clear error pointing users at the bootstrap script."""
+    from crawlers.auth import google_manager
+
+    storage_file = tmp_path / "state.json"
+    storage_file.write_text(json.dumps({"cookies": [], "origins": []}))
+
+    config = {
+        "mode": "oauth_user",
+        "storage_state_path": str(storage_file),
+    }
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    pw_factory, _ctx, _page = _build_playwright_chain(
+        cookies=[],
+        final_url="https://accounts.google.com/ServiceLogin?continue=...",
+    )
+
+    with patch.object(google_manager, "sync_playwright", return_value=pw_factory):
+        mgr = google_manager.GoogleAuthManager(config, secrets)
+        with pytest.raises(RuntimeError, match="google_bootstrap"):
+            mgr.get_authenticated_cookies()
+
+
+def test_get_authenticated_cookies_raises_when_no_storage_state_configured():
+    from crawlers.auth import google_manager
+
+    config = {"mode": "oauth_user"}  # no storage_state_path
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    mgr = google_manager.GoogleAuthManager(config, secrets)
+    with pytest.raises(RuntimeError, match="storage_state"):
+        mgr.get_authenticated_cookies()
+
+
+def test_get_authenticated_cookies_raises_when_storage_state_file_missing(tmp_path):
+    from crawlers.auth import google_manager
+
+    config = {
+        "mode": "oauth_user",
+        "storage_state_path": str(tmp_path / "does_not_exist.json"),
+    }
+    secrets = {"credentials_file": "/tmp/oauth.json"}
+
+    mgr = google_manager.GoogleAuthManager(config, secrets)
+    with pytest.raises(RuntimeError, match="bootstrap"):
+        mgr.get_authenticated_cookies()

--- a/tests/test_google_auth_manager.py
+++ b/tests/test_google_auth_manager.py
@@ -154,7 +154,9 @@ def test_get_credentials_service_account_delegates_to_gdrive_helper():
     secrets = {"credentials_file": "/tmp/sa.json"}
 
     fake_creds = MagicMock(name="fake_sa_creds")
-    with patch.object(google_manager, "get_credentials", return_value=fake_creds) as helper:
+    with patch.object(
+        google_manager, "get_service_account_credentials", return_value=fake_creds
+    ) as helper:
         mgr = google_manager.GoogleAuthManager(config, secrets)
         result = mgr.get_credentials()
 

--- a/tests/test_indexer_utils.py
+++ b/tests/test_indexer_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from core.indexer_utils import auth_redirect_reason, normalize_url_for_metadata
+from core.indexer_utils import auth_redirect_reason, is_auth_host, normalize_url_for_metadata
 
 
 class TestAuthRedirectReason(unittest.TestCase):
@@ -69,6 +69,33 @@ class TestAuthRedirectReason(unittest.TestCase):
         self.assertIsNone(auth_redirect_reason(None, "https://accounts.google.com/x"))
         self.assertIsNone(auth_redirect_reason("https://example.com", None))
         self.assertIsNone(auth_redirect_reason("", ""))
+
+
+class TestIsAuthHost(unittest.TestCase):
+    """`is_auth_host` flags URLs whose host is itself a sign-in / IdP host,
+    independent of any prior redirect. Used to drop links like
+    `accounts.google.com/SignOutOptions` that are embedded as direct links
+    in partially-authenticated pages."""
+
+    def test_flags_accounts_google(self):
+        self.assertTrue(is_auth_host(
+            "https://accounts.google.com/SignOutOptions?continue=https://sites.google.com/..."
+        ))
+
+    def test_flags_okta_subdomain(self):
+        self.assertTrue(is_auth_host("https://acme.okta.com/login/sso"))
+
+    def test_does_not_flag_content_host(self):
+        self.assertFalse(is_auth_host("https://sites.google.com/d/abc/preview"))
+
+    def test_does_not_flag_lookalike(self):
+        # Same suffix-precision guard as auth_redirect_reason.
+        self.assertFalse(is_auth_host("https://fakeokta.com/login"))
+
+    def test_handles_missing_or_relative(self):
+        self.assertFalse(is_auth_host(None))
+        self.assertFalse(is_auth_host(""))
+        self.assertFalse(is_auth_host("/relative/path"))
 
 
 class TestNormalizeUrlForMetadata(unittest.TestCase):

--- a/tests/test_indexer_utils.py
+++ b/tests/test_indexer_utils.py
@@ -1,0 +1,91 @@
+import unittest
+
+from core.indexer_utils import auth_redirect_reason, normalize_url_for_metadata
+
+
+class TestAuthRedirectReason(unittest.TestCase):
+    """Tests for sign-in/IdP redirect detection.
+
+    Real-world trigger (sites.google.com private page without valid auth):
+    crawler fetches `sites.google.com/d/.../p/.../edit`, gets bounced to
+    `accounts.google.com/v3/signin/identifier?continue=...`, and would
+    otherwise index the Google sign-in form's HTML as if it were content.
+    """
+
+    def test_flags_google_signin_redirect(self):
+        reason = auth_redirect_reason(
+            "https://sites.google.com/d/abc/p/xyz/edit",
+            "https://accounts.google.com/v3/signin/identifier?continue=https%3A%2F%2Fsites.google.com%2Fd%2Fabc%2Fp%2Fxyz%2Fedit",
+        )
+        self.assertIsNotNone(reason)
+        self.assertIn("accounts.google.com", reason)
+
+    def test_flags_okta_subdomain_redirect(self):
+        reason = auth_redirect_reason(
+            "https://internal.example.com/wiki",
+            "https://acme.okta.com/login/sso?fromURI=...",
+        )
+        self.assertIsNotNone(reason)
+        self.assertIn("okta.com", reason)
+
+    def test_flags_microsoftonline_redirect(self):
+        reason = auth_redirect_reason(
+            "https://example.sharepoint.com/sites/x",
+            "https://login.microsoftonline.com/common/oauth2/authorize?...",
+        )
+        self.assertIsNotNone(reason)
+
+    def test_no_redirect_same_url(self):
+        # No domain change — caller did not get bounced.
+        self.assertIsNone(auth_redirect_reason(
+            "https://example.com/a",
+            "https://example.com/a",
+        ))
+
+    def test_no_flag_same_domain_login_path(self):
+        # Intentionally conservative: same-domain /login is NOT flagged.
+        # Plenty of legitimate sites serve login content on their own domain.
+        self.assertIsNone(auth_redirect_reason(
+            "https://example.com/dashboard",
+            "https://example.com/login?next=/dashboard",
+        ))
+
+    def test_no_flag_crawling_idp_directly(self):
+        # If the user explicitly crawls accounts.google.com, no domain change
+        # happened — don't flag.
+        self.assertIsNone(auth_redirect_reason(
+            "https://accounts.google.com/foo",
+            "https://accounts.google.com/bar",
+        ))
+
+    def test_no_flag_lookalike_domain(self):
+        # 'fakeokta.com' must NOT be matched by the 'okta.com' suffix rule.
+        self.assertIsNone(auth_redirect_reason(
+            "https://internal.example.com/wiki",
+            "https://fakeokta.com/login",
+        ))
+
+    def test_handles_missing_urls(self):
+        self.assertIsNone(auth_redirect_reason(None, "https://accounts.google.com/x"))
+        self.assertIsNone(auth_redirect_reason("https://example.com", None))
+        self.assertIsNone(auth_redirect_reason("", ""))
+
+
+class TestNormalizeUrlForMetadata(unittest.TestCase):
+    """Round-trip behavior we now rely on in _remove_old_content_if_needed."""
+
+    def test_decodes_percent_encoded_url(self):
+        encoded = "https://accounts.google.com/v3/signin/identifier?continue=https%3A%2F%2Fsites.google.com%2Fd%2Fabc%2Fp%2Fxyz%2Fedit"
+        decoded = "https://accounts.google.com/v3/signin/identifier?continue=https://sites.google.com/d/abc/p/xyz/edit"
+        self.assertEqual(normalize_url_for_metadata(encoded), decoded)
+
+    def test_decoded_url_is_idempotent(self):
+        url = "https://example.com/a b?c=d&e=f"
+        self.assertEqual(
+            normalize_url_for_metadata(normalize_url_for_metadata(url)),
+            normalize_url_for_metadata(url),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_page_crawl_worker.py
+++ b/tests/test_page_crawl_worker.py
@@ -62,19 +62,28 @@ class TestPageCrawlWorkerGoogleAuth(unittest.TestCase):
             credentials_file="/tmp/creds.json",
         )
         fake = _fake_indexer()
+        fake.web_extractor.skip_static_prefetch = False
 
         with patch("crawlers.website_crawler.Indexer", return_value=fake), \
              patch("crawlers.website_crawler.normalize_vectara_endpoint", return_value="https://api.vectara.io"), \
              patch("crawlers.website_crawler.setup_logging"), \
              patch("crawlers.website_crawler.GoogleAuthManager") as MockGAM:
-            MockGAM.return_value.get_authenticated_cookies.return_value = {
-                "SID": "sid-val",
-                "__Secure-1PSID": "psid-val",
-            }
+            MockGAM.return_value.get_authenticated_cookies.return_value = [
+                {"name": "SID", "value": "sid-val", "domain": ".google.com",
+                 "path": "/", "secure": True},
+                {"name": "__Secure-1PSID", "value": "psid-val",
+                 "domain": ".google.com", "path": "/", "secure": True},
+            ]
+            MockGAM.return_value.storage_state_path = "/tmp/s.json"
             worker.setup()
 
-        self.assertEqual(fake.session.cookies.get("SID"), "sid-val")
-        self.assertEqual(fake.session.cookies.get("__Secure-1PSID"), "psid-val")
+        self.assertEqual(
+            fake.session.cookies.get("SID", domain=".google.com"), "sid-val",
+        )
+        self.assertEqual(
+            fake.session.cookies.get("__Secure-1PSID", domain=".google.com"),
+            "psid-val",
+        )
 
     def test_setup_does_not_build_useless_bearer_session(self):
         # Pre-fix behavior: worker called get_authenticated_session() and
@@ -91,7 +100,11 @@ class TestPageCrawlWorkerGoogleAuth(unittest.TestCase):
              patch("crawlers.website_crawler.normalize_vectara_endpoint", return_value="https://api.vectara.io"), \
              patch("crawlers.website_crawler.setup_logging"), \
              patch("crawlers.website_crawler.GoogleAuthManager") as MockGAM:
-            MockGAM.return_value.get_authenticated_cookies.return_value = {"SID": "x"}
+            MockGAM.return_value.get_authenticated_cookies.return_value = [
+                {"name": "SID", "value": "x", "domain": ".google.com",
+                 "path": "/", "secure": True},
+            ]
+            MockGAM.return_value.storage_state_path = "/tmp/s.json"
             worker.setup()
 
             MockGAM.return_value.get_authenticated_session.assert_not_called()

--- a/tests/test_page_crawl_worker.py
+++ b/tests/test_page_crawl_worker.py
@@ -1,0 +1,102 @@
+"""Spec tests for PageCrawlWorker — the per-process Ray actor / single-process
+worker that performs the actual page indexing.
+
+Background: PageCrawlWorker runs in its own process (Ray actor or fork). It
+constructs its own Indexer at `setup()` time and is responsible for wiring
+auth state into that indexer. Cookies don't survive cross-process transfer
+of the parent's Indexer instance, so each worker re-derives them.
+
+Before the fix, the Google branch of `setup()` built a Bearer-token session
+that was useless for `sites.google.com` content URLs. The fix replaces it
+with cookie capture from the persisted Playwright `storage_state`.
+"""
+
+import sys
+import importlib.machinery
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+# Heavy optional deps that the import chain touches.
+for mod in ["cairosvg", "whisper", "pdf2image"]:
+    sys.modules.setdefault(mod, MagicMock())
+_playwright_mock = MagicMock()
+_playwright_mock.__spec__ = importlib.machinery.ModuleSpec("playwright", None)
+sys.modules.setdefault("playwright", _playwright_mock)
+sys.modules.setdefault("playwright.sync_api", MagicMock())
+
+from crawlers.website_crawler import PageCrawlWorker
+
+
+def _build_worker(google_auth_cfg=None, credentials_file=None):
+    cfg = {
+        "vectara": {
+            "endpoint": "https://api.vectara.io",
+            "corpus_key": "k",
+            "api_key": "ak",
+        },
+        "website_crawler": {},
+    }
+    if google_auth_cfg:
+        cfg["website_crawler"]["google_auth"] = google_auth_cfg
+        if credentials_file is not None:
+            cfg["website_crawler"]["google_credentials_file"] = credentials_file
+    return PageCrawlWorker(cfg, num_per_second=5)
+
+
+def _fake_indexer():
+    indexer = MagicMock()
+    indexer.session = requests.Session()
+    indexer.web_extractor = MagicMock()
+    indexer.web_extractor.browser = MagicMock()
+    indexer.web_extractor.browser.new_context = MagicMock(return_value=MagicMock())
+    return indexer
+
+
+class TestPageCrawlWorkerGoogleAuth(unittest.TestCase):
+
+    def test_setup_injects_google_cookies_into_worker_indexer_session(self):
+        worker = _build_worker(
+            google_auth_cfg={"mode": "oauth_user", "storage_state_path": "/tmp/s.json"},
+            credentials_file="/tmp/creds.json",
+        )
+        fake = _fake_indexer()
+
+        with patch("crawlers.website_crawler.Indexer", return_value=fake), \
+             patch("crawlers.website_crawler.normalize_vectara_endpoint", return_value="https://api.vectara.io"), \
+             patch("crawlers.website_crawler.setup_logging"), \
+             patch("crawlers.website_crawler.GoogleAuthManager") as MockGAM:
+            MockGAM.return_value.get_authenticated_cookies.return_value = {
+                "SID": "sid-val",
+                "__Secure-1PSID": "psid-val",
+            }
+            worker.setup()
+
+        self.assertEqual(fake.session.cookies.get("SID"), "sid-val")
+        self.assertEqual(fake.session.cookies.get("__Secure-1PSID"), "psid-val")
+
+    def test_setup_does_not_build_useless_bearer_session(self):
+        # Pre-fix behavior: worker called get_authenticated_session() and
+        # assigned the Bearer-only session as indexer.session. That session
+        # is rejected by sites.google.com content URLs (docs say so) and
+        # forced credentials_file to be present even for cookie-only crawls.
+        worker = _build_worker(
+            google_auth_cfg={"mode": "oauth_user", "storage_state_path": "/tmp/s.json"},
+            credentials_file="/tmp/creds.json",
+        )
+        fake = _fake_indexer()
+
+        with patch("crawlers.website_crawler.Indexer", return_value=fake), \
+             patch("crawlers.website_crawler.normalize_vectara_endpoint", return_value="https://api.vectara.io"), \
+             patch("crawlers.website_crawler.setup_logging"), \
+             patch("crawlers.website_crawler.GoogleAuthManager") as MockGAM:
+            MockGAM.return_value.get_authenticated_cookies.return_value = {"SID": "x"}
+            worker.setup()
+
+            MockGAM.return_value.get_authenticated_session.assert_not_called()
+            MockGAM.return_value.get_authenticated_cookies.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_page_crawl_worker.py
+++ b/tests/test_page_crawl_worker.py
@@ -29,7 +29,8 @@ sys.modules.setdefault("playwright.sync_api", MagicMock())
 from crawlers.website_crawler import PageCrawlWorker
 
 
-def _build_worker(google_auth_cfg=None, credentials_file=None):
+def _build_worker(google_auth_cfg=None, credentials_file=None, saml_auth_cfg=None,
+                  saml_username=None, saml_password=None):
     cfg = {
         "vectara": {
             "endpoint": "https://api.vectara.io",
@@ -42,6 +43,12 @@ def _build_worker(google_auth_cfg=None, credentials_file=None):
         cfg["website_crawler"]["google_auth"] = google_auth_cfg
         if credentials_file is not None:
             cfg["website_crawler"]["google_credentials_file"] = credentials_file
+    if saml_auth_cfg:
+        cfg["website_crawler"]["saml_auth"] = saml_auth_cfg
+        if saml_username is not None:
+            cfg["website_crawler"]["saml_username"] = saml_username
+        if saml_password is not None:
+            cfg["website_crawler"]["saml_password"] = saml_password
     return PageCrawlWorker(cfg, num_per_second=5)
 
 
@@ -109,6 +116,53 @@ class TestPageCrawlWorkerGoogleAuth(unittest.TestCase):
 
             MockGAM.return_value.get_authenticated_session.assert_not_called()
             MockGAM.return_value.get_authenticated_cookies.assert_called_once()
+
+
+class TestPageCrawlWorkerSamlAuth(unittest.TestCase):
+    """The SAML worker branch must wire auth into both `indexer.session` and
+    `indexer.web_extractor` via `_apply_auth_to_indexer`. A bare session
+    assignment would leave `skip_static_prefetch` off, so the unauthenticated
+    static prefetch in `WebContentExtractor.fetch_page_contents` follows
+    redirects to the IdP login page and short-circuits the Playwright path —
+    SAML-only crawls would never see authenticated content."""
+
+    def test_setup_routes_saml_through_apply_auth_to_indexer(self):
+        worker = _build_worker(
+            saml_auth_cfg={"idp_url": "https://idp.example.com"},
+            saml_username="user",
+            saml_password="pw",
+        )
+        fake = _fake_indexer()
+        fake.web_extractor.skip_static_prefetch = False
+        original_new_context = fake.web_extractor.browser.new_context
+
+        saml_session_sentinel = requests.Session()
+
+        with patch("crawlers.website_crawler.Indexer", return_value=fake), \
+             patch("crawlers.website_crawler.normalize_vectara_endpoint", return_value="https://api.vectara.io"), \
+             patch("crawlers.website_crawler.setup_logging"), \
+             patch("crawlers.website_crawler.SAMLAuthManager") as MockSAM:
+            MockSAM.return_value.get_authenticated_session.return_value = saml_session_sentinel
+            worker.setup()
+
+        # requests session wired
+        self.assertIs(fake.session, saml_session_sentinel)
+        # static prefetch bypassed so IdP HTML can't poison the result
+        self.assertTrue(fake.web_extractor.skip_static_prefetch)
+        # new_context replaced with the cookie-transferring wrapper
+        self.assertIsNot(fake.web_extractor.browser.new_context, original_new_context)
+
+    def test_setup_raises_when_saml_secrets_missing(self):
+        # Guards against a regression where the secrets check is bypassed
+        # before the auth wiring is attempted.
+        worker = _build_worker(saml_auth_cfg={"idp_url": "https://idp.example.com"})
+        fake = _fake_indexer()
+
+        with patch("crawlers.website_crawler.Indexer", return_value=fake), \
+             patch("crawlers.website_crawler.normalize_vectara_endpoint", return_value="https://api.vectara.io"), \
+             patch("crawlers.website_crawler.setup_logging"):
+            with self.assertRaises(ValueError):
+                worker.setup()
 
 
 if __name__ == "__main__":

--- a/tests/test_spider_auth_redirect.py
+++ b/tests/test_spider_auth_redirect.py
@@ -1,0 +1,84 @@
+"""Discovery-side guard: spider must not extract links from IdP sign-in
+pages it lands on after a cross-domain redirect.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+for mod in ["cairosvg", "whisper", "pdf2image"]:
+    sys.modules.setdefault(mod, MagicMock())
+
+import pytest
+from scrapy.http import HtmlResponse, Request
+
+from core.spider import LinkSpider, recursive_crawl
+
+
+_IDP_SIGNIN_HTML = b"""
+<html><body>
+  <form action="/signin"><input name="user"></form>
+  <a href="https://accounts.google.com/signin/v2/usernamerecovery">Forgot?</a>
+  <a href="https://accounts.google.com/lifecycle/steps/signup/name">Create account</a>
+  <a href="https://support.google.com/accounts/answer/2917834">Learn more</a>
+</body></html>
+"""
+
+
+def _make_spider():
+    return LinkSpider(
+        start_urls=["https://sites.google.com/d/abc/p/xyz/edit"],
+        positive_regexes=[".*"],
+        negative_regexes=[],
+        max_depth=2,
+    )
+
+
+def test_linkspider_drops_links_when_redirected_to_google_signin():
+    spider = _make_spider()
+    original = "https://sites.google.com/d/abc/p/xyz/edit"
+    landed = "https://accounts.google.com/v3/signin/identifier?continue=..."
+    request = Request(landed, meta={"depth": 0, "redirect_urls": [original]})
+    response = HtmlResponse(url=landed, request=request, body=_IDP_SIGNIN_HTML)
+
+    items = list(spider.parse(response))
+    assert items == [], "Spider must not yield URLs or follow links from an IdP landing page"
+
+
+def test_linkspider_processes_normal_response():
+    spider = _make_spider()
+    url = "https://sites.google.com/d/abc/p/xyz/edit"
+    request = Request(url, meta={"depth": 0})
+    body = b'<html><body><a href="/page2">Next</a></body></html>'
+    response = HtmlResponse(url=url, request=request, body=body)
+
+    items = list(spider.parse(response))
+    # Should yield the page itself plus the follow-up request for /page2.
+    urls_yielded = [i.get("url") for i in items if isinstance(i, dict)]
+    requests_yielded = [i.url for i in items if isinstance(i, Request)]
+    assert url in urls_yielded
+    assert "https://sites.google.com/page2" in requests_yielded
+
+
+def test_recursive_crawl_drops_discovery_on_idp_redirect():
+    indexer = MagicMock()
+    # Simulate Playwright following the redirect to an IdP page that still
+    # contains some "links" we definitely should NOT enqueue.
+    indexer.fetch_page_contents.return_value = {
+        "url": "https://accounts.google.com/v3/signin/identifier?continue=...",
+        "links": [
+            "https://accounts.google.com/signin/v2/usernamerecovery",
+            "https://accounts.google.com/lifecycle/steps/signup/name",
+        ],
+        "text": "Sign in", "html": "<html></html>", "title": "Sign in",
+    }
+    visited = recursive_crawl(
+        "https://sites.google.com/d/abc/p/xyz/edit",
+        depth=2, pos_patterns=[], neg_patterns=[], indexer=indexer,
+    )
+    # The seed URL itself is still recorded (it's what the caller asked us
+    # to start from), but none of the IdP links should be picked up.
+    assert visited == {"https://sites.google.com/d/abc/p/xyz/edit"}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_spider_auth_redirect.py
+++ b/tests/test_spider_auth_redirect.py
@@ -44,6 +44,43 @@ def test_linkspider_drops_links_when_redirected_to_google_signin():
     assert items == [], "Spider must not yield URLs or follow links from an IdP landing page"
 
 
+def test_linkspider_drops_direct_link_to_idp_host():
+    """Regression: when an authenticated page body contains a direct link to
+    an IdP host (e.g. accounts.google.com/SignOutOptions), Scrapy should
+    follow neither yield the URL nor crawl deeper into it. Previously this
+    leaked into urls_indexed.txt because auth_redirect_reason only fires on
+    a netloc change during the same fetch."""
+    spider = _make_spider()
+    # The response URL is itself on the IdP host — no prior redirect.
+    landed = "https://accounts.google.com/SignOutOptions?continue=https://sites.google.com/..."
+    request = Request(landed, meta={"depth": 0})
+    response = HtmlResponse(url=landed, request=request, body=_IDP_SIGNIN_HTML)
+
+    items = list(spider.parse(response))
+    assert items == [], "Spider must drop IdP-host responses, not yield them"
+
+
+def test_linkspider_does_not_follow_idp_links_from_authenticated_page():
+    """Regression: an authenticated page may include account-management
+    links (sign out, switch account). Those point to accounts.google.com
+    and should not be followed even though the response itself is fine."""
+    spider = _make_spider()
+    url = "https://sites.google.com/d/abc/p/xyz/edit"
+    request = Request(url, meta={"depth": 0})
+    body = (
+        b'<html><body>'
+        b'<a href="https://accounts.google.com/SignOutOptions">Sign out</a>'
+        b'<a href="/page2">Next</a>'
+        b'</body></html>'
+    )
+    response = HtmlResponse(url=url, request=request, body=body)
+
+    items = list(spider.parse(response))
+    follow_urls = [i.url for i in items if isinstance(i, Request)]
+    assert "https://sites.google.com/page2" in follow_urls
+    assert not any("accounts.google.com" in u for u in follow_urls)
+
+
 def test_linkspider_processes_normal_response():
     spider = _make_spider()
     url = "https://sites.google.com/d/abc/p/xyz/edit"
@@ -78,6 +115,44 @@ def test_recursive_crawl_drops_discovery_on_idp_redirect():
     # The seed URL itself is still recorded (it's what the caller asked us
     # to start from), but none of the IdP links should be picked up.
     assert visited == {"https://sites.google.com/d/abc/p/xyz/edit"}
+
+
+def test_linkspider_start_forwards_cookie_list_with_attributes():
+    """Bug A regression: when cookies are passed as a list-of-dicts (the
+    format Scrapy needs to enforce per-cookie domain scoping for `__Host-*`
+    and other host-bound Google cookies), `start()` must forward the list
+    verbatim to each Scrapy Request — no flattening, no attribute loss."""
+    import asyncio
+
+    cookies = [
+        {"name": "SID", "value": "sid", "domain": ".google.com",
+         "path": "/", "secure": True},
+        {"name": "__Host-1PLSID", "value": "psid",
+         "domain": "accounts.google.com", "path": "/", "secure": True},
+    ]
+    spider = LinkSpider(
+        start_urls=["https://sites.google.com/site/home"],
+        positive_regexes=[".*"],
+        negative_regexes=[],
+        max_depth=1,
+        cookies=cookies,
+    )
+
+    async def _collect():
+        return [r async for r in spider.start()]
+
+    requests_yielded = asyncio.run(_collect())
+    assert len(requests_yielded) == 1
+    req = requests_yielded[0]
+    # Scrapy Request stores the raw cookies kwarg until CookieMiddleware
+    # consumes it. We assert structural equality so the test stays robust
+    # against Scrapy internals.
+    assert req.cookies == cookies
+    # Per-cookie attributes are still present (i.e. nothing was flattened
+    # to a {name: value} dict along the way).
+    by_name = {c["name"]: c for c in req.cookies}
+    assert by_name["__Host-1PLSID"]["domain"] == "accounts.google.com"
+    assert by_name["__Host-1PLSID"]["secure"] is True
 
 
 if __name__ == "__main__":

--- a/tests/test_spider_middleware.py
+++ b/tests/test_spider_middleware.py
@@ -1,0 +1,48 @@
+import inspect
+import sys
+from unittest.mock import MagicMock
+
+for mod in ["cairosvg", "whisper", "pdf2image"]:
+    sys.modules.setdefault(mod, MagicMock())
+
+import pytest
+from scrapy.downloadermiddlewares.redirect import RedirectMiddleware
+from scrapy.exceptions import IgnoreRequest
+from scrapy.http import Request
+from scrapy.settings import Settings
+
+from core.spider import FilterRedirectsByTypeMiddleware
+
+
+def test_redirect_signature_matches_parent():
+    parent_sig = inspect.signature(RedirectMiddleware._redirect)
+    child_sig = inspect.signature(FilterRedirectsByTypeMiddleware._redirect)
+    assert list(parent_sig.parameters) == list(child_sig.parameters)
+
+
+def _make_mw():
+    settings = Settings({
+        "REDIRECT_ENABLED": True,
+        "REDIRECT_MAX_TIMES": 20,
+        "REDIRECT_PRIORITY_ADJUST": 2,
+    })
+    mw = FilterRedirectsByTypeMiddleware(settings)
+    # Scrapy 2.14's RedirectMiddleware._redirect logs via self.crawler.spider.
+    mw.crawler = MagicMock()
+    return mw
+
+
+def test_redirect_to_disallowed_type_is_ignored():
+    mw = _make_mw()
+    request = Request("http://example.com/page")
+    redirected = Request("http://example.com/file.zip")
+    with pytest.raises(IgnoreRequest):
+        mw._redirect(redirected, request, 302)
+
+
+def test_redirect_to_allowed_type_passes_through():
+    mw = _make_mw()
+    request = Request("http://example.com/page")
+    redirected = Request("http://example.com/next")
+    result = mw._redirect(redirected, request, 302)
+    assert result.url == "http://example.com/next"

--- a/tests/test_web_content_extractor_auth.py
+++ b/tests/test_web_content_extractor_auth.py
@@ -1,0 +1,143 @@
+"""Bug B regression: when auth is wired into the indexer's web_extractor,
+the unauthenticated `requests.get` static prefetch in `fetch_page_contents`
+must be skipped so the authenticated Playwright path actually runs.
+
+Without this guard, Google Sites (and any other auth-required SPA) returns
+~1KB of redirect-to-signin HTML which exceeds the 500-char threshold and
+short-circuits the browser path entirely.
+"""
+
+import importlib.machinery
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import requests
+
+# Heavy native deps that the import chain touches.
+for _mod in ["cairosvg", "whisper", "pdf2image"]:
+    sys.modules.setdefault(_mod, MagicMock())
+_pw_mock = MagicMock()
+_pw_mock.__spec__ = importlib.machinery.ModuleSpec("playwright", None)
+sys.modules.setdefault("playwright", _pw_mock)
+sys.modules.setdefault("playwright.sync_api", MagicMock())
+
+
+def _make_extractor():
+    """Build a WebContentExtractor with a stub browser so `__init__` does
+    not try to launch Chromium."""
+    from core.web_content_extractor import WebContentExtractor
+
+    cfg = SimpleNamespace(
+        vectara=SimpleNamespace(get=lambda key, default=None: default),
+    )
+    fake_browser = MagicMock(name="browser")
+    extractor = WebContentExtractor(cfg=cfg, browser=fake_browser)
+    # Constructor sets these only when browser is None; mirror them so the
+    # browser-path code doesn't trip on missing attrs.
+    extractor.p = MagicMock(name="playwright_runner")
+    return extractor
+
+
+class TestSkipStaticPrefetchFlag(unittest.TestCase):
+
+    def test_default_is_false(self):
+        extractor = _make_extractor()
+        self.assertFalse(extractor.skip_static_prefetch)
+
+    def test_when_true_requests_get_is_not_called(self):
+        extractor = _make_extractor()
+        extractor.skip_static_prefetch = True
+
+        # Make the browser path return a benign result so we exercise the
+        # whole function but don't depend on Playwright internals.
+        page = MagicMock()
+        page.title.return_value = "ok"
+        page.url = "https://sites.google.com/site/home"
+        page.content.return_value = "<html></html>"
+        context = MagicMock()
+        context.new_page.return_value = page
+        extractor.browser.new_context.return_value = context
+
+        with patch("core.web_content_extractor.requests.get",
+                   side_effect=AssertionError("static prefetch must be skipped")) as mock_get, \
+             patch.object(extractor, "_extract_text_content", return_value="rendered text"), \
+             patch.object(extractor, "_extract_links", return_value=[]), \
+             patch.object(extractor, "_remove_elements"), \
+             patch.object(extractor, "_scroll_to_bottom"):
+            result = extractor.fetch_page_contents("https://sites.google.com/site/home")
+
+        mock_get.assert_not_called()
+        # Browser path was actually taken
+        extractor.browser.new_context.assert_called()
+        self.assertEqual(result["text"], "rendered text")
+
+    def test_when_false_static_prefetch_runs(self):
+        extractor = _make_extractor()
+        # default is False — be explicit
+        extractor.skip_static_prefetch = False
+
+        # Static response with >500 chars of visible text so the static
+        # branch commits and returns before any browser logic.
+        fake_resp = MagicMock()
+        fake_resp.headers = {"content-type": "text/html"}
+        fake_resp.url = "https://example.com/page"
+        fake_resp.text = "<html><body>" + ("hello world " * 100) + "</body></html>"
+        fake_resp.raise_for_status = MagicMock()
+
+        with patch("core.web_content_extractor.requests.get", return_value=fake_resp) as mock_get:
+            result = extractor.fetch_page_contents("https://example.com/page")
+
+        mock_get.assert_called_once()
+        # Browser path must NOT have been invoked when static is sufficient
+        extractor.browser.new_context.assert_not_called()
+        self.assertGreater(len(result["text"]), 500)
+
+
+class TestApplyAuthSetsSkipFlag(unittest.TestCase):
+    """`_apply_auth_to_indexer` is the chokepoint that knows auth is wired
+    in. It must flip `skip_static_prefetch` so per-page fetches go through
+    the authenticated Playwright context, never plain `requests.get`."""
+
+    def _fake_indexer(self):
+        indexer = MagicMock()
+        indexer.session = requests.Session()
+        indexer.web_extractor = MagicMock()
+        indexer.web_extractor.skip_static_prefetch = False
+        indexer.web_extractor.browser = MagicMock()
+        indexer.web_extractor.browser.new_context = MagicMock(return_value=MagicMock())
+        return indexer
+
+    def test_google_auth_sets_skip_flag(self):
+        from crawlers.website_crawler import _apply_auth_to_indexer
+
+        indexer = self._fake_indexer()
+        _apply_auth_to_indexer(
+            indexer,
+            google_cookies=None,
+            google_storage_state_path="/tmp/state.json",
+        )
+        self.assertTrue(indexer.web_extractor.skip_static_prefetch)
+
+    def test_saml_session_sets_skip_flag(self):
+        from crawlers.website_crawler import _apply_auth_to_indexer
+
+        indexer = self._fake_indexer()
+        _apply_auth_to_indexer(
+            indexer,
+            saml_session=requests.Session(),
+        )
+        self.assertTrue(indexer.web_extractor.skip_static_prefetch)
+
+    def test_no_auth_leaves_flag_alone(self):
+        from crawlers.website_crawler import _apply_auth_to_indexer
+
+        indexer = self._fake_indexer()
+        _apply_auth_to_indexer(indexer)
+        # Should remain at its default (False) — no auth, no need to skip.
+        self.assertFalse(indexer.web_extractor.skip_static_prefetch)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_website_crawler.py
+++ b/tests/test_website_crawler.py
@@ -119,18 +119,20 @@ class TestSetupGoogleAuth(unittest.TestCase):
         fake_self = SimpleNamespace(
             cfg=_google_auth_cfg(credentials_file="/tmp/creds.json"),
             google_cookies=None,
+            google_storage_state_path=None,
         )
+        captured = [
+            {"name": "SID", "value": "sid-val", "domain": ".google.com",
+             "path": "/", "secure": True},
+            {"name": "__Secure-1PSID", "value": "psid-val",
+             "domain": ".google.com", "path": "/", "secure": True},
+        ]
         with patch("crawlers.website_crawler.GoogleAuthManager") as MockGAM:
-            MockGAM.return_value.get_authenticated_cookies.return_value = {
-                "SID": "sid-val",
-                "__Secure-1PSID": "psid-val",
-            }
+            MockGAM.return_value.get_authenticated_cookies.return_value = captured
+            MockGAM.return_value.storage_state_path = "/tmp/s.json"
             WebsiteCrawler._setup_google_auth(fake_self)
 
-        self.assertEqual(
-            fake_self.google_cookies,
-            {"SID": "sid-val", "__Secure-1PSID": "psid-val"},
-        )
+        self.assertEqual(fake_self.google_cookies, captured)
         # No Bearer session is constructed any more.
         MockGAM.return_value.get_authenticated_session.assert_not_called()
 
@@ -139,12 +141,16 @@ class TestSetupGoogleAuth(unittest.TestCase):
         fake_self = SimpleNamespace(
             cfg=_google_auth_cfg(credentials_file=None),
             google_cookies=None,
+            google_storage_state_path=None,
         )
+        cookies = [{"name": "SID", "value": "x", "domain": ".google.com",
+                    "path": "/", "secure": True}]
         with patch("crawlers.website_crawler.GoogleAuthManager") as MockGAM:
-            MockGAM.return_value.get_authenticated_cookies.return_value = {"SID": "x"}
+            MockGAM.return_value.get_authenticated_cookies.return_value = cookies
+            MockGAM.return_value.storage_state_path = "/tmp/s.json"
             WebsiteCrawler._setup_google_auth(fake_self)
 
-        self.assertEqual(fake_self.google_cookies, {"SID": "x"})
+        self.assertEqual(fake_self.google_cookies, cookies)
         # Manager was constructed with an empty secrets dict.
         _, kwargs = MockGAM.call_args
         secrets = kwargs.get("secrets") if "secrets" in kwargs else MockGAM.call_args.args[1]
@@ -154,7 +160,9 @@ class TestSetupGoogleAuth(unittest.TestCase):
         fake_cfg = SimpleNamespace(
             website_crawler=SimpleNamespace(get=lambda key, default=None: default),
         )
-        fake_self = SimpleNamespace(cfg=fake_cfg, google_cookies=None)
+        fake_self = SimpleNamespace(
+            cfg=fake_cfg, google_cookies=None, google_storage_state_path=None,
+        )
         with patch("crawlers.website_crawler.GoogleAuthManager") as MockGAM:
             WebsiteCrawler._setup_google_auth(fake_self)
 
@@ -170,10 +178,12 @@ class TestConfigureIndexerSession(unittest.TestCase):
     Scrapy discovery succeeded.
     """
 
-    def _build_fake_self(self, *, google_cookies=None, saml_session=None):
+    def _build_fake_self(self, *, google_cookies=None, saml_session=None,
+                          google_storage_state_path=None):
         fake_indexer = MagicMock()
         fake_indexer.session = requests.Session()
         fake_indexer.web_extractor = MagicMock()
+        fake_indexer.web_extractor.skip_static_prefetch = False
         fake_indexer.web_extractor.browser = MagicMock()
         # original new_context returns a context whose add_cookies we can spy on
         original_context = MagicMock(name="context")
@@ -182,35 +192,53 @@ class TestConfigureIndexerSession(unittest.TestCase):
             indexer=fake_indexer,
             saml_session=saml_session,
             google_cookies=google_cookies,
+            google_storage_state_path=google_storage_state_path,
         ), original_context
 
     def test_merges_google_cookies_into_indexer_session(self):
-        fake_self, _ctx = self._build_fake_self(
-            google_cookies={"SID": "sid-val", "__Secure-1PSID": "psid-val"},
-        )
+        cookies = [
+            {"name": "SID", "value": "sid-val", "domain": ".google.com",
+             "path": "/", "secure": True},
+            {"name": "__Secure-1PSID", "value": "psid-val",
+             "domain": ".google.com", "path": "/", "secure": True},
+        ]
+        fake_self, _ctx = self._build_fake_self(google_cookies=cookies)
         WebsiteCrawler._configure_indexer_session(fake_self)
 
-        self.assertEqual(fake_self.indexer.session.cookies.get("SID"), "sid-val")
+        # Cookies are scoped to their actual domain in the requests jar, not
+        # smeared across every host like .update({name: value}) would do.
         self.assertEqual(
-            fake_self.indexer.session.cookies.get("__Secure-1PSID"), "psid-val"
+            fake_self.indexer.session.cookies.get("SID", domain=".google.com"),
+            "sid-val",
+        )
+        self.assertEqual(
+            fake_self.indexer.session.cookies.get("__Secure-1PSID", domain=".google.com"),
+            "psid-val",
         )
 
-    def test_injects_google_cookies_into_playwright_context(self):
+    def test_google_storage_state_wires_into_playwright_new_context(self):
+        # Google's authenticated Playwright context comes from `storage_state`
+        # — re-injecting individual cookies via `add_cookies` fails on
+        # __Host-/__Secure- cookies because Chromium rejects the batch.
         fake_self, original_context = self._build_fake_self(
-            google_cookies={"SID": "sid-val"},
+            google_storage_state_path="/tmp/state.json",
         )
+        # Capture the original (pre-wrap) new_context MagicMock so we can
+        # inspect its kwargs after the wrapper invokes it.
+        original_new_context = fake_self.indexer.web_extractor.browser.new_context
+
         WebsiteCrawler._configure_indexer_session(fake_self)
 
-        # The override should have replaced new_context. Call it and confirm
-        # Google cookies were forwarded to the context via add_cookies.
-        new_ctx = fake_self.indexer.web_extractor.browser.new_context()
-        self.assertIs(new_ctx, original_context)
-        original_context.add_cookies.assert_called()
-        forwarded = []
-        for call in original_context.add_cookies.call_args_list:
-            forwarded.extend(call.args[0])
-        names = {c["name"]: c["value"] for c in forwarded}
-        self.assertEqual(names.get("SID"), "sid-val")
+        # Calling the wrapped new_context must forward `storage_state` into
+        # the original Playwright `new_context` call.
+        fake_self.indexer.web_extractor.browser.new_context()
+        _, kwargs = original_new_context.call_args
+        self.assertEqual(kwargs.get("storage_state"), "/tmp/state.json")
+        # No add_cookies path — storage_state carries cookies into Chromium.
+        original_context.add_cookies.assert_not_called()
+        # And the static-prefetch flag is flipped so per-page fetches go
+        # through the authenticated Playwright context.
+        self.assertTrue(fake_self.indexer.web_extractor.skip_static_prefetch)
 
     def test_no_auth_configured_leaves_session_alone(self):
         fake_self, _ctx = self._build_fake_self()
@@ -220,6 +248,8 @@ class TestConfigureIndexerSession(unittest.TestCase):
         self.assertEqual(len(fake_self.indexer.session.cookies), 0)
         # new_context override is also not installed when nothing is configured.
         fake_self.indexer._init_processors.assert_not_called()
+        # And the static-prefetch flag should remain at default (False).
+        self.assertFalse(fake_self.indexer.web_extractor.skip_static_prefetch)
 
 
 class TestInternalCrawlerDiscovery(unittest.TestCase):

--- a/tests/test_website_crawler.py
+++ b/tests/test_website_crawler.py
@@ -1,0 +1,258 @@
+import sys
+import importlib.machinery
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import requests
+
+# Heavy optional deps that website_crawler's import chain touches.
+for mod in ["cairosvg", "whisper", "pdf2image"]:
+    sys.modules.setdefault(mod, MagicMock())
+_playwright_mock = MagicMock()
+_playwright_mock.__spec__ = importlib.machinery.ModuleSpec("playwright", None)
+sys.modules.setdefault("playwright", _playwright_mock)
+sys.modules.setdefault("playwright.sync_api", MagicMock())
+
+from crawlers.website_crawler import WebsiteCrawler
+
+
+def _make_cfg(remove_old_content=True, crawl_report=False):
+    return SimpleNamespace(
+        website_crawler=SimpleNamespace(
+            get=lambda key, default=None: {
+                "remove_old_content": remove_old_content,
+                "crawl_report": crawl_report,
+            }.get(key, default)
+        ),
+        vectara=SimpleNamespace(get=lambda key, default=None: default),
+    )
+
+
+class TestRemoveOldContentEncoding(unittest.TestCase):
+    """Regression tests for the urls_indexed/urls_removed encoding mismatch.
+
+    Background: the indexer URL-decodes metadata['url'] via
+    normalize_url_for_metadata before storing it, while crawled_urls comes
+    directly from URL discovery and can be percent-encoded. A naive string
+    comparison flagged the *same* logical URL as both indexed and removed,
+    causing repeated delete/reindex churn across crawls.
+    """
+
+    def _run(self, crawled_urls, existing_docs):
+        fake_indexer = MagicMock()
+        fake_indexer._list_docs.return_value = existing_docs
+        fake_self = SimpleNamespace(cfg=_make_cfg(), indexer=fake_indexer)
+        WebsiteCrawler._remove_old_content_if_needed(fake_self, crawled_urls)
+        return [c.args[0] for c in fake_indexer.delete_doc.call_args_list]
+
+    def test_percent_encoded_discovery_matches_decoded_corpus_url(self):
+        # Same logical URL, discovery percent-encoded, corpus URL-decoded.
+        crawled = [
+            "https://accounts.google.com/v3/signin/identifier?"
+            "continue=https%3A%2F%2Fsites.google.com%2Fd%2Fabc%2Fp%2Fxyz%2Fedit"
+        ]
+        existing = [{
+            "id": "doc1",
+            "url": "https://accounts.google.com/v3/signin/identifier?"
+                   "continue=https://sites.google.com/d/abc/p/xyz/edit",
+        }]
+        deleted = self._run(crawled, existing)
+        self.assertEqual(deleted, [], "Should not delete a URL that was just indexed")
+
+    def test_decoded_discovery_matches_decoded_corpus_url(self):
+        # Both sides already decoded — must still match.
+        url = "https://example.com/p?q=a b&x=1"
+        deleted = self._run([url], [{"id": "doc1", "url": url}])
+        self.assertEqual(deleted, [])
+
+    def test_genuinely_missing_url_is_deleted(self):
+        crawled = ["https://example.com/keep"]
+        existing = [
+            {"id": "keep", "url": "https://example.com/keep"},
+            {"id": "gone", "url": "https://example.com/gone"},
+        ]
+        deleted = self._run(crawled, existing)
+        self.assertEqual(deleted, ["gone"])
+
+    def test_doc_without_url_is_ignored(self):
+        # Docs without a url in metadata shouldn't get deleted.
+        deleted = self._run(["https://example.com/a"], [{"id": "no-url", "url": None}])
+        self.assertEqual(deleted, [])
+
+    def test_disabled_when_remove_old_content_false(self):
+        fake_indexer = MagicMock()
+        fake_self = SimpleNamespace(
+            cfg=_make_cfg(remove_old_content=False), indexer=fake_indexer
+        )
+        WebsiteCrawler._remove_old_content_if_needed(fake_self, [])
+        fake_indexer._list_docs.assert_not_called()
+        fake_indexer.delete_doc.assert_not_called()
+
+
+def _google_auth_cfg(credentials_file=None, pages_source="crawl"):
+    """Build a fake cfg that exposes a `website_crawler.google_auth` block.
+
+    The crawler reads `google_credentials_file` as a flat attribute (stamped
+    by ingest.py from `GOOGLE_CREDENTIALS_FILE`) and `google_auth` via .get().
+    """
+    overrides = {
+        "google_auth": {"mode": "oauth_user", "storage_state_path": "/tmp/s.json"},
+        "pages_source": pages_source,
+    }
+    website_crawler_ns = SimpleNamespace(
+        get=lambda key, default=None: overrides.get(key, default),
+    )
+    if credentials_file is not None:
+        website_crawler_ns.google_credentials_file = credentials_file
+    return SimpleNamespace(website_crawler=website_crawler_ns)
+
+
+class TestSetupGoogleAuth(unittest.TestCase):
+    """Spec: `_setup_google_auth` captures `sites.google.com` browser cookies
+    once at crawler init and stashes them on `self.google_cookies`. The old
+    Bearer-token session is gone — Bearer headers are rejected by
+    `sites.google.com` content URLs, so building the session was dead weight.
+    """
+
+    def test_fetches_cookies_into_google_cookies(self):
+        fake_self = SimpleNamespace(
+            cfg=_google_auth_cfg(credentials_file="/tmp/creds.json"),
+            google_cookies=None,
+        )
+        with patch("crawlers.website_crawler.GoogleAuthManager") as MockGAM:
+            MockGAM.return_value.get_authenticated_cookies.return_value = {
+                "SID": "sid-val",
+                "__Secure-1PSID": "psid-val",
+            }
+            WebsiteCrawler._setup_google_auth(fake_self)
+
+        self.assertEqual(
+            fake_self.google_cookies,
+            {"SID": "sid-val", "__Secure-1PSID": "psid-val"},
+        )
+        # No Bearer session is constructed any more.
+        MockGAM.return_value.get_authenticated_session.assert_not_called()
+
+    def test_works_without_credentials_file_for_cookie_only_crawls(self):
+        # Storage-state-only flow: no GOOGLE_CREDENTIALS_FILE in secrets.toml.
+        fake_self = SimpleNamespace(
+            cfg=_google_auth_cfg(credentials_file=None),
+            google_cookies=None,
+        )
+        with patch("crawlers.website_crawler.GoogleAuthManager") as MockGAM:
+            MockGAM.return_value.get_authenticated_cookies.return_value = {"SID": "x"}
+            WebsiteCrawler._setup_google_auth(fake_self)
+
+        self.assertEqual(fake_self.google_cookies, {"SID": "x"})
+        # Manager was constructed with an empty secrets dict.
+        _, kwargs = MockGAM.call_args
+        secrets = kwargs.get("secrets") if "secrets" in kwargs else MockGAM.call_args.args[1]
+        self.assertIsNone(secrets.get("credentials_file"))
+
+    def test_skips_when_google_auth_block_not_configured(self):
+        fake_cfg = SimpleNamespace(
+            website_crawler=SimpleNamespace(get=lambda key, default=None: default),
+        )
+        fake_self = SimpleNamespace(cfg=fake_cfg, google_cookies=None)
+        with patch("crawlers.website_crawler.GoogleAuthManager") as MockGAM:
+            WebsiteCrawler._setup_google_auth(fake_self)
+
+        self.assertIsNone(fake_self.google_cookies)
+        MockGAM.assert_not_called()
+
+
+class TestConfigureIndexerSession(unittest.TestCase):
+    """Spec: `_configure_indexer_session` propagates auth state to BOTH the
+    indexer's `requests.Session` (for HTTP fetches) and the Playwright
+    `web_extractor` (for JS-rendered fetches). Without this, page content
+    fetches against `sites.google.com` 302 to accounts.google.com even when
+    Scrapy discovery succeeded.
+    """
+
+    def _build_fake_self(self, *, google_cookies=None, saml_session=None):
+        fake_indexer = MagicMock()
+        fake_indexer.session = requests.Session()
+        fake_indexer.web_extractor = MagicMock()
+        fake_indexer.web_extractor.browser = MagicMock()
+        # original new_context returns a context whose add_cookies we can spy on
+        original_context = MagicMock(name="context")
+        fake_indexer.web_extractor.browser.new_context = MagicMock(return_value=original_context)
+        return SimpleNamespace(
+            indexer=fake_indexer,
+            saml_session=saml_session,
+            google_cookies=google_cookies,
+        ), original_context
+
+    def test_merges_google_cookies_into_indexer_session(self):
+        fake_self, _ctx = self._build_fake_self(
+            google_cookies={"SID": "sid-val", "__Secure-1PSID": "psid-val"},
+        )
+        WebsiteCrawler._configure_indexer_session(fake_self)
+
+        self.assertEqual(fake_self.indexer.session.cookies.get("SID"), "sid-val")
+        self.assertEqual(
+            fake_self.indexer.session.cookies.get("__Secure-1PSID"), "psid-val"
+        )
+
+    def test_injects_google_cookies_into_playwright_context(self):
+        fake_self, original_context = self._build_fake_self(
+            google_cookies={"SID": "sid-val"},
+        )
+        WebsiteCrawler._configure_indexer_session(fake_self)
+
+        # The override should have replaced new_context. Call it and confirm
+        # Google cookies were forwarded to the context via add_cookies.
+        new_ctx = fake_self.indexer.web_extractor.browser.new_context()
+        self.assertIs(new_ctx, original_context)
+        original_context.add_cookies.assert_called()
+        forwarded = []
+        for call in original_context.add_cookies.call_args_list:
+            forwarded.extend(call.args[0])
+        names = {c["name"]: c["value"] for c in forwarded}
+        self.assertEqual(names.get("SID"), "sid-val")
+
+    def test_no_auth_configured_leaves_session_alone(self):
+        fake_self, _ctx = self._build_fake_self()
+        WebsiteCrawler._configure_indexer_session(fake_self)
+
+        # No cookies should land in the session.
+        self.assertEqual(len(fake_self.indexer.session.cookies), 0)
+        # new_context override is also not installed when nothing is configured.
+        fake_self.indexer._init_processors.assert_not_called()
+
+
+class TestInternalCrawlerDiscovery(unittest.TestCase):
+    """Spec: when discovering URLs via the internal (non-Scrapy) path,
+    sitemap_to_urls receives the indexer's merged session — which carries
+    Google cookies after `_configure_indexer_session` has run. This is the
+    BUG 1 fix: previously only `self.saml_session` was passed, leaving
+    google_auth a silent no-op in the default crawl_method.
+    """
+
+    def test_sitemap_path_uses_indexer_session_not_saml_session(self):
+        fake_indexer = MagicMock()
+        fake_indexer.session = MagicMock(name="indexer_session_with_google_cookies")
+        fake_indexer.verbose = False
+
+        fake_self = SimpleNamespace(
+            cfg=_google_auth_cfg(pages_source="sitemap"),
+            indexer=fake_indexer,
+            saml_session=MagicMock(name="saml_session"),
+            pos_patterns=[],
+            neg_patterns=[],
+        )
+
+        with patch("crawlers.website_crawler.sitemap_to_urls", return_value=[]) as mock_s2u:
+            WebsiteCrawler._discover_urls_with_internal_crawler(
+                fake_self, ["https://example.com"], max_depth=1, keep_query_params=False
+            )
+
+        mock_s2u.assert_called_once()
+        _, kwargs = mock_s2u.call_args
+        self.assertIs(kwargs.get("session"), fake_indexer.session)
+        self.assertIsNot(kwargs.get("session"), fake_self.saml_session)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a `google_auth` config block to the website crawler so private
Google Sites (and other Google-gated URLs) can be crawled with real
authentication, and fixes a Scrapy 2.14 compatibility break that was
zeroing out every redirected URL.

### `google_auth` for the website crawler

Mirrors the existing `saml_auth` block. Two auth modes:

- **`oauth_user`** — one-time consent, works without Workspace admin.
- **`service_account`** — DWD-impersonated Workspace user.

`sites.google.com` requires real browser cookies (not just bearer
tokens), so cookies are captured once via a new interactive bootstrap
CLI (`python -m crawlers.auth.google_bootstrap`) and reused at crawl
time by loading the Playwright `storage_state` JSON. The crawler
fails fast with a clear pointer back to the bootstrap when the stored
session is missing or expired. When both `saml_auth` and `google_auth`
are configured, their cookies are merged.

New module layout:
- `crawlers/auth/google_manager.py` — runtime cookie/session manager.
- `crawlers/auth/google_bootstrap.py` — interactive one-time login CLI.
- `docs/GOOGLE_AUTHENTICATION.md` — setup walkthrough for both modes.

### Scrapy 2.14 redirect fix

`FilterRedirectsByTypeMiddleware._redirect` was overriding the base
`RedirectMiddleware._redirect` with the old 4-arg signature. Scrapy
2.14.2 dropped the `spider` parameter from built-in downloader
middleware `_redirect` calls, so every redirected URL was crashing
with a `TypeError` and the crawler was reporting 0 indexed URLs on
any site that does a top-level redirect. Signature now matches
2.14.x.

### Other small fixes bundled in `765e9c7`

- `web_content_extractor` and `spider` now propagate the Google auth
  cookies/storage state through Playwright correctly.
- `crawl_tracker` and `indexer_utils` tweaks needed to keep auth
  state consistent across worker processes.
- `.gitignore` ignores the captured `storage_state` JSON so secrets
  don't get committed.

## Test plan

- [x] New unit tests pass:
  - `tests/test_google_auth_manager.py`
  - `tests/test_spider_auth_redirect.py`
  - `tests/test_spider_middleware.py`
  - `tests/test_web_content_extractor_auth.py`
  - `tests/test_page_crawl_worker.py`
  - `tests/test_crawl_tracker.py`
  - `tests/test_indexer_utils.py`
  - `tests/test_website_crawler.py`
- [ ] Reviewer to run the bootstrap CLI against a real Google account
  and crawl a private `sites.google.com` URL end-to-end.
- [ ] Reviewer to confirm a public site that issues a top-level
  redirect (e.g. `http://` → `https://`) now indexes pages instead of
  reporting 0 URLs — that's the Scrapy 2.14 regression.
- [ ] Confirm `saml_auth` + `google_auth` configured together still
  produces a single merged cookie jar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)