### PR TITLE
Add Wolken KB ACL metadata and corpus routing

### DIFF
--- a/config/wolken-kb.yaml
+++ b/config/wolken-kb.yaml
@@ -34,3 +34,32 @@ wolken_crawler:
     - environment
     - resolution
     - additionalInfo
+
+  # Corpus routing mode. Use "single_corpus" to index all articles into vectara.corpus_key.
+  # Use "multi_corpus" with corpus_mappings to route articles by product metadata.
+  mode: single_corpus
+
+  # Product fields to inspect when routing by corpus_mappings. Dot paths are supported.
+  product_fields:
+    - productname
+    - products
+    - product
+    - articleOtherInfo.productname
+    - articleOtherInfo.products
+
+  # Metadata key used to store extracted products.
+  metadata_product_key: product
+
+  # Optional multi-corpus product routing. Each key is a target Vectara corpus key; each value
+  # is the list of Wolken product names that should route to that corpus.
+  # corpus_mappings:
+  #   vmware-cloud-foundation-wolken-kb:
+  #     - VMware Cloud Foundation
+  #   tanzu-wolken-kb:
+  #     - Tanzu
+
+  # Optional ACL/entitlement extraction. Dot paths are searched in article summary/details and
+  # articleOtherInfo/articleOtherInfoVO. Results are stored in entitlements_metadata_key.
+  acl_fields: []
+  entitlements_metadata_key: entitlements
+  default_entitlements: []

--- a/crawlers/wolken_crawler.py
+++ b/crawlers/wolken_crawler.py
@@ -13,12 +13,16 @@ Flow:
 4. For each article, fetch full details and index into Vectara
 """
 
+import json
 import logging
 import re
 import time
+from collections.abc import Iterable
+from typing import Any
 
 import requests
 from core.crawler import Crawler
+from core.indexer import Indexer
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +39,32 @@ def clean_html(text: str) -> str:
 def _str_or_empty(v) -> str:
     """Convert a value to string, mapping None to empty string (avoids 'None' literal in metadata)."""
     return "" if v is None else str(v)
+
+
+def _as_plain_container(value: Any) -> Any:
+    """Convert OmegaConf containers to plain Python containers when OmegaConf is available."""
+    try:
+        from omegaconf import OmegaConf
+
+        if OmegaConf.is_config(value):
+            return OmegaConf.to_container(value, resolve=True)
+    except Exception:
+        pass
+    return value
+
+
+def _dedupe_strings(values: Iterable[Any]) -> list[str]:
+    """Return non-empty string values in input order, without duplicates."""
+    seen = set()
+    result = []
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text and text not in seen:
+            seen.add(text)
+            result.append(text)
+    return result
 
 
 class WolkenCrawler(Crawler):
@@ -55,9 +85,28 @@ class WolkenCrawler(Crawler):
         self.kb_source_id = crawler_cfg.get("kb_source_id", None)
 
         # Content fields to extract from articleOtherInfo
-        self.content_fields = crawler_cfg.get("content_fields", [
+        self.content_fields = list(crawler_cfg.get("content_fields", [
             "introduction", "cause", "environment", "resolution", "additionalInfo"
-        ])
+        ]))
+
+        self.corpus_key = corpus_key
+        self.endpoint = endpoint
+        self.api_key = api_key
+        self.mode = crawler_cfg.get("mode", "single_corpus")
+        self.corpus_mappings = _as_plain_container(crawler_cfg.get("corpus_mappings", {})) or {}
+        self.product_fields = list(crawler_cfg.get("product_fields", [
+            "productname", "products", "product", "articleOtherInfo.productname", "articleOtherInfo.products"
+        ]))
+        self.metadata_product_key = crawler_cfg.get("metadata_product_key", "product")
+        self.acl_fields = list(crawler_cfg.get("acl_fields", []))
+        self.entitlements_metadata_key = crawler_cfg.get("entitlements_metadata_key", "entitlements")
+        self.default_entitlements = self._normalize_list(crawler_cfg.get("default_entitlements", []))
+
+        self.indexers = {corpus_key: self.indexer}
+        if self.mode == "multi_corpus":
+            for target_corpus_key in self.corpus_mappings.keys():
+                if target_corpus_key != corpus_key:
+                    self.indexers[target_corpus_key] = Indexer(cfg, endpoint, target_corpus_key, api_key)
 
         self.access_token = None
         self.token_expires_at = 0
@@ -210,6 +259,120 @@ class WolkenCrawler(Crawler):
 
         return sections
 
+    def _field_value(self, data: dict, path: str) -> Any:
+        """Return a nested dict value using a dotted field path."""
+        current = data
+        for part in path.split("."):
+            if not isinstance(current, dict):
+                return None
+            current = current.get(part)
+            if current is None:
+                return None
+        return current
+
+    def _candidate_roots(self, details: dict, article: dict) -> list[dict]:
+        roots = [details or {}, article or {}]
+        for root in list(roots):
+            if isinstance(root, dict):
+                for child_key in ("articleOtherInfo", "articleOtherInfoVO"):
+                    child = root.get(child_key)
+                    if isinstance(child, dict):
+                        roots.append(child)
+        return roots
+
+    def _normalize_list(self, value: Any) -> list[str]:
+        """Normalize string/list/dict-ish API values to a list of strings."""
+        value = _as_plain_container(value)
+        if value is None or value == "":
+            return []
+        if isinstance(value, str):
+            raw = value.strip()
+            if not raw:
+                return []
+            try:
+                parsed = json.loads(raw)
+                if parsed != value:
+                    return self._normalize_list(parsed)
+            except Exception:
+                pass
+            if "," in raw:
+                return _dedupe_strings(part.strip() for part in raw.split(","))
+            return [raw]
+        if isinstance(value, dict):
+            for key in ("name", "value", "id", "email"):
+                if key in value:
+                    return self._normalize_list(value[key])
+            return _dedupe_strings(value.values())
+        if isinstance(value, Iterable):
+            flattened = []
+            for item in value:
+                flattened.extend(self._normalize_list(item))
+            return _dedupe_strings(flattened)
+        return [str(value)]
+
+    def _extract_products(self, details: dict, article: dict = None) -> list[str]:
+        """Extract product names from configured fields in article summary/details."""
+        products = []
+        for root in self._candidate_roots(details, article or {}):
+            for field in self.product_fields:
+                products.extend(self._normalize_list(self._field_value(root, field)))
+        return _dedupe_strings(products)
+
+    def _extract_entitlements(self, details: dict, article: dict = None) -> list[str]:
+        """Extract ACL/entitlement values from configured fields and defaults."""
+        entitlements = list(self.default_entitlements)
+        for root in self._candidate_roots(details, article or {}):
+            for field in self.acl_fields:
+                entitlements.extend(self._normalize_list(self._field_value(root, field)))
+        return _dedupe_strings(entitlements)
+
+    def _determine_target_corpora(self, details: dict, article: dict = None) -> list[str]:
+        """Determine which corpus/corpora should receive this article."""
+        if self.mode != "multi_corpus":
+            return [self.corpus_key]
+
+        products = self._extract_products(details, article or {})
+        target_corpora = []
+        for target_corpus, mapped_products in self.corpus_mappings.items():
+            normalized_mapping = {p.strip() for p in self._normalize_list(mapped_products)}
+            if any(product.strip() in normalized_mapping for product in products):
+                target_corpora.append(target_corpus)
+
+        if not target_corpora:
+            article_id = details.get("articleId") or (article or {}).get("articleId")
+            logger.warning(
+                "Article %s with products %s does not match corpus_mappings; using primary corpus %s",
+                article_id, products, self.corpus_key,
+            )
+            target_corpora = [self.corpus_key]
+        return _dedupe_strings(target_corpora)
+
+    def _index_article(self, doc_id: str, texts: list[str], titles: list[str], metadata: dict, title: str,
+                       details: dict, article: dict) -> bool:
+        """Index an article into each selected target corpus."""
+        target_corpora = self._determine_target_corpora(details, article)
+        all_succeeded = True
+        for target_corpus in target_corpora:
+            indexer = self.indexers.get(target_corpus)
+            if indexer is None:
+                logger.error("No indexer configured for target corpus %s", target_corpus)
+                all_succeeded = False
+                continue
+
+            corpus_metadata = dict(metadata)
+            if self.mode == "multi_corpus":
+                corpus_metadata["target_corpus"] = target_corpus
+
+            succeeded = indexer.index_segments(
+                doc_id=doc_id,
+                texts=texts,
+                titles=titles,
+                doc_metadata=corpus_metadata,
+                doc_title=title,
+            )
+            all_succeeded = all_succeeded and succeeded
+        return all_succeeded
+
     def crawl(self) -> None:
         """Main crawl loop: categories → articles → details → index."""
         categories = self._get_categories()
@@ -278,21 +441,22 @@ class WolkenCrawler(Crawler):
                         "published_date": _str_or_empty(other_info.get("publishedDate")),
                     }
 
+                    products = self._extract_products(details, article)
+                    if products:
+                        metadata[self.metadata_product_key] = products
+
+                    # Always include the entitlement metadata key so filters have a stable schema.
+                    metadata[self.entitlements_metadata_key] = self._extract_entitlements(details, article)
+
                     # Build article URL if available
-                    url_name = details.get("articleUrlName", "")
+                    url_name = details.get("articleUrlName", "") or details.get("extArticleUrl", "")
                     if url_name:
                         metadata["url"] = url_name
 
                     texts = [text for _, text in content_sections]
                     titles = [section_title for section_title, _ in content_sections]
 
-                    succeeded = self.indexer.index_segments(
-                        doc_id=doc_id,
-                        texts=texts,
-                        titles=titles,
-                        doc_metadata=metadata,
-                        doc_title=title,
-                    )
+                    succeeded = self._index_article(doc_id, texts, titles, metadata, title, details, article)
 
                     if succeeded:
                         total_indexed += 1

--- a/docs/wolken-kb-setup.md
+++ b/docs/wolken-kb-setup.md
@@ -10,7 +10,8 @@ The Wolken KB crawler uses the [public Wolken Knowledge Base REST API](https://d
 2. Fetches all KB categories
 3. For each category, fetches all articles (with pagination)
 4. For each article, fetches the full details (introduction, cause, resolution, etc.)
-5. Indexes each article as a structured document in Vectara
+5. Extracts configured product and ACL/entitlement metadata
+6. Indexes each article as a structured document in one or more Vectara corpora
 
 ## Prerequisites
 
@@ -88,26 +89,50 @@ WOLKEN_REFRESH_TOKEN = "your-refresh-token"
 
 All keys prefixed with `WOLKEN_` are automatically mapped to the `wolken_crawler` config section with the prefix stripped and lowercased. For example, `WOLKEN_API_ENDPOINT` becomes `wolken_crawler.api_endpoint`.
 
-When using `secrets.toml`, you can leave the credential fields empty in the YAML config:
+When using `secrets.toml`, you can leave the credential fields empty in the YAML config.
+
+### 3. Optional: configure ACL/entitlement metadata
+
+The crawler can extract ACL values from configurable Wolken fields. Dot paths are supported and are evaluated against article summary data, article detail data, and nested `articleOtherInfo` / `articleOtherInfoVO` objects.
 
 ```yaml
 wolken_crawler:
-  api_endpoint: ""
-  domain: ""
-  client_id: ""
-  service_account: ""
-  auth_code: ""
-  refresh_token: ""
-  batch_size: 100
-  content_fields:
-    - introduction
-    - cause
-    - environment
-    - resolution
-    - additionalInfo
+  acl_fields:
+    - entitlements
+    - accessGroups
+    - articleOtherInfo.visibilityGroups
+  entitlements_metadata_key: entitlements
+  default_entitlements:
+    - public
 ```
 
-### 3. Run the crawler
+If no ACL values are present, the crawler still writes the configured entitlement metadata key with an empty list (or `default_entitlements` if set) so downstream filters have a stable schema.
+
+### 4. Optional: configure product-to-corpus routing
+
+By default, all articles are indexed into `vectara.corpus_key` (`single_corpus` mode). For dev or customer deployments that require corpus mapping, enable `multi_corpus` and define exact product-name mappings:
+
+```yaml
+vectara:
+  corpus_key: wolken-kb-default
+
+wolken_crawler:
+  mode: multi_corpus
+  product_fields:
+    - productname
+    - products
+    - articleOtherInfo.productname
+  metadata_product_key: product
+  corpus_mappings:
+    vmware-cloud-foundation-wolken-kb:
+      - VMware Cloud Foundation
+    tanzu-wolken-kb:
+      - Tanzu
+```
+
+An article is indexed into every mapped corpus whose product list matches. If no mapping matches, the article falls back to `vectara.corpus_key` and a warning is logged.
+
+### 5. Run the crawler
 
 **Using Docker:**
 
@@ -120,6 +145,8 @@ wolken_crawler:
 ```bash
 python ingest.py --config-file config/wolken-kb.yaml --profile default
 ```
+
+For an initial dev load, set `reindex: true` if you want to replace existing documents; otherwise leave `reindex: false` to skip documents tracked as already indexed.
 
 ## Configuration Options
 
@@ -134,6 +161,13 @@ python ingest.py --config-file config/wolken-kb.yaml --profile default
 | `batch_size` | integer | 100 | Number of items per API page |
 | `kb_source_id` | integer | none | Filter categories by KB source ID |
 | `content_fields` | list | see below | Fields to extract from article details |
+| `mode` | string | `single_corpus` | `single_corpus` or `multi_corpus` |
+| `product_fields` | list | see config | Wolken fields used for product extraction/routing |
+| `metadata_product_key` | string | `product` | Metadata key for extracted products |
+| `corpus_mappings` | map | `{}` | Target corpus key to product-name list mapping |
+| `acl_fields` | list | `[]` | Wolken fields used for ACL/entitlement extraction |
+| `entitlements_metadata_key` | string | `entitlements` | Metadata key for extracted ACL values |
+| `default_entitlements` | list | `[]` | Entitlements to apply to every article |
 
 ### Content Fields
 
@@ -171,6 +205,9 @@ Each article is indexed as a Vectara document with:
   - `validation_status_id`: Validation status
   - `published_date`: Publication date
   - `url`: Article URL (if available)
+  - `product` (configurable): Extracted product names, when present
+  - `entitlements` (configurable): Extracted ACL/entitlement values
+  - `target_corpus`: Target corpus key when `mode: multi_corpus`
 
 ## Resume Support
 

--- a/tests/test_wolken_crawler_routing.py
+++ b/tests/test_wolken_crawler_routing.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock
+
+from tests.test_wolken_crawler import _make_crawler
+
+
+def _make_routing_crawler():
+    crawler = _make_crawler()
+    crawler.corpus_key = "default-wolken-kb"
+    crawler.endpoint = "https://api.vectara.io"
+    crawler.api_key = "test-api-key"
+    crawler.mode = "multi_corpus"
+    crawler.corpus_mappings = {
+        "vcf-wolken-kb": ["VMware Cloud Foundation"],
+        "tanzu-wolken-kb": ["Tanzu"],
+    }
+    crawler.product_fields = ["productname", "articleOtherInfo.products"]
+    crawler.metadata_product_key = "product"
+    crawler.acl_fields = ["entitlements", "articleOtherInfo.accessGroups"]
+    crawler.entitlements_metadata_key = "entitlements"
+    crawler.default_entitlements = ["public"]
+    crawler.indexers = {
+        "default-wolken-kb": MagicMock(),
+        "vcf-wolken-kb": MagicMock(),
+        "tanzu-wolken-kb": MagicMock(),
+    }
+    return crawler
+
+
+class TestWolkenRoutingAndAcl:
+
+    def test_extract_products_from_json_string_and_nested_fields(self):
+        crawler = _make_routing_crawler()
+        details = {
+            "productname": '["VMware Cloud Foundation", "Tanzu"]',
+            "articleOtherInfo": {
+                "products": ["VMware Cloud Foundation", "Aria"]
+            },
+        }
+
+        products = crawler._extract_products(details)
+
+        assert products == ["VMware Cloud Foundation", "Tanzu", "Aria"]
+
+    def test_extract_entitlements_from_defaults_and_configured_fields(self):
+        crawler = _make_routing_crawler()
+        details = {
+            "entitlements": "premium, support",
+            "articleOtherInfo": {
+                "accessGroups": ["vcf-users", {"name": "admins"}]
+            },
+        }
+
+        entitlements = crawler._extract_entitlements(details)
+
+        assert entitlements == ["public", "premium", "support", "vcf-users", "admins"]
+
+    def test_determine_target_corpora_routes_to_all_matching_mappings(self):
+        crawler = _make_routing_crawler()
+        details = {
+            "productname": '["VMware Cloud Foundation", "Tanzu"]',
+        }
+
+        target_corpora = crawler._determine_target_corpora(details)
+
+        assert target_corpora == ["vcf-wolken-kb", "tanzu-wolken-kb"]
+
+    def test_determine_target_corpora_falls_back_to_primary_corpus(self):
+        crawler = _make_routing_crawler()
+        details = {
+            "articleId": 123,
+            "productname": '["Unmapped Product"]',
+        }
+
+        target_corpora = crawler._determine_target_corpora(details)
+
+        assert target_corpora == ["default-wolken-kb"]
+
+    def test_index_article_adds_target_corpus_metadata_per_destination(self):
+        crawler = _make_routing_crawler()
+        details = {"productname": '["VMware Cloud Foundation", "Tanzu"]'}
+        metadata = {"source": "wolken_kb", "entitlements": ["public"]}
+
+        succeeded = crawler._index_article(
+            doc_id="wolken-kb-123",
+            texts=["body"],
+            titles=["Introduction"],
+            metadata=metadata,
+            title="Article title",
+            details=details,
+            article={},
+        )
+
+        assert succeeded is True
+        crawler.indexers["vcf-wolken-kb"].index_segments.assert_called_once()
+        crawler.indexers["tanzu-wolken-kb"].index_segments.assert_called_once()
+        assert (
+            crawler.indexers["vcf-wolken-kb"].index_segments.call_args.kwargs["doc_metadata"]["target_corpus"]
+            == "vcf-wolken-kb"
+        )
+        assert (
+            crawler.indexers["tanzu-wolken-kb"].index_segments.call_args.kwargs["doc_metadata"]["target_corpus"]
+            == "tanzu-wolken-kb"
+        )


### PR DESCRIPTION
## Summary

Adds Wolken KB ingestion support for the task "Ingest - Wolken KB":

- configurable ACL/entitlement extraction into document metadata
- configurable product extraction
- `single_corpus` (default/current behavior) and `multi_corpus` product→corpus routing
- docs/config examples for dev/customer full-load setup
- tests for ACL extraction and routing behavior

## Approach

The existing `WolkenCrawler` behavior is preserved by default (`mode: single_corpus`). New options under `wolken_crawler` allow operators to:

- define `acl_fields`, `entitlements_metadata_key`, and `default_entitlements`
- define `product_fields`, `metadata_product_key`, and `corpus_mappings`
- route a Wolken article to every target corpus with a matching product; fallback remains `vectara.corpus_key`

Field extraction supports dotted paths and handles list/JSON-string/comma-separated values without converting nulls to string `"None"`.

## Tests

Added `tests/test_wolken_crawler_routing.py` covering:

- product extraction from JSON strings and nested fields
- entitlement extraction from defaults and configured ACL fields
- multi-corpus routing to all matching corpora
- fallback to primary corpus when no mapping matches
- per-destination `target_corpus` metadata

Not run in this environment (remote-only implementation via GitHub API).

## Assumptions / follow-ups

- Exact Wolken ACL field names are tenant-specific, so the PR makes them configurable rather than hard-coding Broadcom-specific names.
- The actual initial load to dev still requires Wolken credentials and Vectara dev API credentials; this PR provides the code/config support for an operator to run it.