### PR TITLE
Add configurable Fluid Topics crawler

### DIFF
--- a/config/fluidtopics.yaml
+++ b/config/fluidtopics.yaml
@@ -1,0 +1,58 @@
+vectara:
+  corpus_key: fluid-topics
+  reindex: false
+  create_corpus: false
+  # Optional: apply Presidio PII masking to structured text/metadata before indexing.
+  mask_pii: false
+
+crawling:
+  crawler_type: fluidtopics
+
+fluidtopics_crawler:
+  # Fluid Topics tenant base URL, e.g. https://docs.example.fluidtopics.net
+  base_url: ""
+
+  # API key auth. Keep api_key in secrets.toml as FLUIDTOPICS_API_KEY or
+  # FLUID_TOPICS_API_KEY instead of committing it here.
+  api_key: ""
+  api_key_header: "X-FluidTopics-Api-Key"
+  # Set to "Bearer" if the tenant expects Authorization: Bearer <token>.
+  auth_scheme: ""
+
+  # The Fluid Topics API surface can differ by tenant/version. Configure the
+  # list/search endpoint and per-item content endpoint to match the tenant docs.
+  search_endpoint: "/api/search"
+  content_endpoint_template: "/api/topics/{id}"
+
+  # Search/list parameters.
+  query: "*"
+  query_param: "q"
+  page_param: "page"
+  page_size_param: "limit"
+  page_size: 100
+  start_page: 0
+  # since_param: "modifiedSince"
+  # since: "2026-01-01T00:00:00Z"
+
+  # JSON paths used to read list items and content records.
+  # Override these to match the tenant's API response shape.
+  # items_path: "results"
+  id_paths: ["id", "khubId", "contentId", "topicId", "mapId"]
+  title_paths: ["title", "name", "label", "metadata.title"]
+  content_paths: ["content", "body", "html", "text", "xml", "dita", "data.content", "data.body"]
+  url_paths: ["url", "htmlUrl", "readerUrl", "metadata.url"]
+
+  # Metadata fields to expose for filtering/access control. Values are JSON
+  # paths read from the merged list item + content detail payload.
+  metadata_paths:
+    device_family: "metadata.device_family"
+    content_type: "metadata.content_type"
+    version: "metadata.version"
+    access_tier: "metadata.access_tier"
+    publication_date: "metadata.publication_date"
+
+  static_metadata:
+    source: "fluid-topics"
+
+  # Source API throttling.
+  num_per_second: 5

--- a/crawlers/fluidtopics_crawler.py
+++ b/crawlers/fluidtopics_crawler.py
@@ -1,0 +1,353 @@
+"""
+Fluid Topics crawler.
+
+Crawls documents/topics from a Fluid Topics tenant using a configurable REST API
+shape and indexes the extracted content into Vectara as structured documents.
+
+The Fluid Topics APIs and response schemas can vary by tenant/version. This
+crawler therefore keeps the source API endpoints, JSON paths, auth header, and
+metadata mapping configurable instead of hard-coding one customer's tenant
+contract.
+"""
+
+import json
+import logging
+import re
+import time
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+from bs4 import BeautifulSoup
+from core.crawler import Crawler
+from core.utils import create_session_with_retries, configure_session_for_ssl, html_to_text
+
+logger = logging.getLogger(__name__)
+
+
+_MISSING = object()
+
+
+def _str_or_empty(value: Any) -> str:
+    """Stringify metadata values without turning None into the literal 'None'."""
+    return "" if value is None else str(value)
+
+
+def _safe_doc_id(value: Any) -> str:
+    """Create a stable Vectara document id fragment."""
+    text = _str_or_empty(value).strip()
+    text = re.sub(r"[^A-Za-z0-9_.-]+", "-", text).strip("-")
+    return text or "unknown"
+
+
+def _get_path(data: Any, path: Optional[str], default: Any = None) -> Any:
+    """Read a dotted path from nested dict/list data.
+
+    Supports simple paths such as `metadata.version` and list indexes such as
+    `results.0.id`. Returns `default` if any segment is missing.
+    """
+    if not path:
+        return default
+    current = data
+    for part in str(path).split("."):
+        if current is None:
+            return default
+        if isinstance(current, dict):
+            current = current.get(part, _MISSING)
+        elif isinstance(current, list) and part.isdigit():
+            index = int(part)
+            current = current[index] if index < len(current) else _MISSING
+        else:
+            return default
+        if current is _MISSING:
+            return default
+    return current
+
+
+def _get_first_path(data: Any, paths: List[str], default: Any = None) -> Any:
+    for path in paths:
+        value = _get_path(data, path, _MISSING)
+        if value is not _MISSING and value is not None and value != "":
+            return value
+    return default
+
+
+def _clean_markup(text: Any) -> str:
+    """Convert Fluid Topics HTML/DITA/XML-like content to plain text."""
+    if text is None:
+        return ""
+    if isinstance(text, (dict, list)):
+        text = json.dumps(text, ensure_ascii=False)
+    text = str(text)
+    if not text.strip():
+        return ""
+    try:
+        if "<" in text and ">" in text:
+            return html_to_text(text).strip()
+    except Exception:
+        logger.debug("html_to_text failed; falling back to BeautifulSoup", exc_info=True)
+    if "<" in text and ">" in text:
+        return BeautifulSoup(text, "lxml").get_text(" ", strip=True)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+class FluidtopicsCrawler(Crawler):
+    """Configurable crawler for Fluid Topics tenants."""
+
+    DEFAULT_ITEM_PATHS = ["results", "items", "topics", "documents", "data", "content"]
+    DEFAULT_ID_PATHS = ["id", "khubId", "contentId", "topicId", "mapId", "document_id"]
+    DEFAULT_TITLE_PATHS = ["title", "name", "label", "metadata.title"]
+    DEFAULT_CONTENT_PATHS = ["content", "body", "html", "text", "xml", "dita", "data.content", "data.body"]
+    DEFAULT_URL_PATHS = ["url", "htmlUrl", "readerUrl", "metadata.url"]
+
+    def __init__(self, cfg, endpoint, corpus_key, api_key):
+        super().__init__(cfg, endpoint, corpus_key, api_key)
+        crawler_cfg = cfg.get("fluidtopics_crawler", {})
+
+        self.base_url = crawler_cfg.get("base_url", "").rstrip("/")
+        if not self.base_url:
+            raise ValueError("fluidtopics_crawler.base_url is required")
+
+        self.fluidtopics_api_key = crawler_cfg.get("api_key", "")
+        if not self.fluidtopics_api_key:
+            raise ValueError("fluidtopics_crawler.api_key is required")
+
+        self.api_key_header = crawler_cfg.get("api_key_header", "X-FluidTopics-Api-Key")
+        self.auth_scheme = crawler_cfg.get("auth_scheme", "")
+        self.search_endpoint = crawler_cfg.get("search_endpoint", "/api/search")
+        self.content_endpoint_template = crawler_cfg.get("content_endpoint_template", "/api/topics/{id}")
+
+        self.query = crawler_cfg.get("query", "*")
+        self.query_param = crawler_cfg.get("query_param", "q")
+        self.extra_params = dict(crawler_cfg.get("params", {}) or {})
+        self.since_param = crawler_cfg.get("since_param", None)
+        self.since = crawler_cfg.get("since", None)
+
+        self.page_param = crawler_cfg.get("page_param", "page")
+        self.page_size_param = crawler_cfg.get("page_size_param", "limit")
+        self.page_size = int(crawler_cfg.get("page_size", 100))
+        self.start_page = int(crawler_cfg.get("start_page", 0))
+        self.max_pages = crawler_cfg.get("max_pages", None)
+        self.next_page_path = crawler_cfg.get("next_page_path", None)
+
+        self.items_path = crawler_cfg.get("items_path", None)
+        self.id_paths = list(crawler_cfg.get("id_paths", self.DEFAULT_ID_PATHS))
+        self.title_paths = list(crawler_cfg.get("title_paths", self.DEFAULT_TITLE_PATHS))
+        self.content_paths = list(crawler_cfg.get("content_paths", self.DEFAULT_CONTENT_PATHS))
+        self.url_paths = list(crawler_cfg.get("url_paths", self.DEFAULT_URL_PATHS))
+        self.metadata_paths = dict(crawler_cfg.get("metadata_paths", {}) or {})
+        self.static_metadata = dict(crawler_cfg.get("static_metadata", {}) or {})
+        self.source = crawler_cfg.get("source", "fluid-topics")
+        self.num_per_second = max(int(crawler_cfg.get("num_per_second", 5)), 1)
+
+        self.session = create_session_with_retries()
+        configure_session_for_ssl(self.session, crawler_cfg)
+
+    def _headers(self) -> Dict[str, str]:
+        value = f"{self.auth_scheme} {self.fluidtopics_api_key}".strip() if self.auth_scheme else self.fluidtopics_api_key
+        return {
+            self.api_key_header: value,
+            "Accept": "application/json, text/html, application/xml, text/xml;q=0.9, */*;q=0.8",
+        }
+
+    def _url(self, endpoint: str) -> str:
+        return urljoin(f"{self.base_url}/", endpoint.lstrip("/"))
+
+    def _request(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        url = self._url(endpoint)
+        response = self.session.get(url, headers=self._headers(), params=params, timeout=60)
+        if response.status_code == 429:
+            retry_after = response.headers.get("Retry-After")
+            wait = int(retry_after) if retry_after and retry_after.isdigit() else 60
+            logger.warning("Fluid Topics rate limited %s; sleeping %ss", url, wait)
+            time.sleep(wait)
+            response = self.session.get(url, headers=self._headers(), params=params, timeout=60)
+        response.raise_for_status()
+
+        content_type = response.headers.get("content-type", "")
+        if "json" in content_type.lower():
+            return response.json()
+        try:
+            return response.json()
+        except Exception:
+            return response.text
+
+    def _extract_items(self, payload: Any) -> List[Dict[str, Any]]:
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        if not isinstance(payload, dict):
+            return []
+
+        paths = [self.items_path] if self.items_path else self.DEFAULT_ITEM_PATHS
+        for path in paths:
+            items = _get_path(payload, path, None)
+            if isinstance(items, list):
+                return [item for item in items if isinstance(item, dict)]
+        return []
+
+    def iter_items(self) -> List[Dict[str, Any]]:
+        """Fetch all item records from the configured search/list endpoint."""
+        items: List[Dict[str, Any]] = []
+        page = self.start_page
+        pages_fetched = 0
+
+        while True:
+            params = dict(self.extra_params)
+            if self.query_param and self.query is not None:
+                params[self.query_param] = self.query
+            if self.page_param:
+                params[self.page_param] = page
+            if self.page_size_param:
+                params[self.page_size_param] = self.page_size
+            if self.since_param and self.since:
+                params[self.since_param] = self.since
+
+            payload = self._request(self.search_endpoint, params=params)
+            batch = self._extract_items(payload)
+            if not batch:
+                break
+
+            items.extend(batch)
+            pages_fetched += 1
+            if self.max_pages is not None and pages_fetched >= int(self.max_pages):
+                break
+
+            next_page = _get_path(payload, self.next_page_path, None) if self.next_page_path else None
+            if next_page is not None:
+                page = next_page
+            else:
+                if len(batch) < self.page_size:
+                    break
+                page += 1
+
+        return items
+
+    def _content_endpoint(self, item: Dict[str, Any], item_id: str) -> str:
+        values = {k: v for k, v in item.items() if isinstance(k, str)}
+        values.update({"id": item_id, "document_id": item_id})
+        return self.content_endpoint_template.format_map(_DefaultFormatDict(values))
+
+    def _fetch_content_record(self, item: Dict[str, Any], item_id: str) -> Any:
+        if not self.content_endpoint_template:
+            return item
+        return self._request(self._content_endpoint(item, item_id))
+
+    def _extract_text(self, item: Dict[str, Any], content_record: Any) -> str:
+        candidates = [content_record, item]
+        for candidate in candidates:
+            if isinstance(candidate, str):
+                text = _clean_markup(candidate)
+                if text:
+                    return text
+            for path in self.content_paths:
+                value = _get_path(candidate, path, None)
+                text = _clean_markup(value)
+                if text:
+                    return text
+        return ""
+
+    def _build_metadata(self, item: Dict[str, Any], content_record: Any, item_id: str, title: str) -> Dict[str, Any]:
+        merged = item.copy()
+        if isinstance(content_record, dict):
+            merged.update(content_record)
+
+        metadata = {
+            "source": self.source,
+            "document_id": _str_or_empty(item_id),
+        }
+        if title:
+            metadata["title"] = title
+
+        url = _get_first_path(merged, self.url_paths, None)
+        if url:
+            metadata["url"] = _str_or_empty(url)
+
+        default_paths = {
+            "device_family": "metadata.device_family",
+            "content_type": "metadata.content_type",
+            "version": "metadata.version",
+            "access_tier": "metadata.access_tier",
+            "publication_date": "metadata.publication_date",
+        }
+        for key, path in {**default_paths, **self.metadata_paths}.items():
+            value = _get_path(merged, path, None)
+            if value is not None:
+                metadata[key] = value
+
+        metadata.update(self.static_metadata)
+        return metadata
+
+    def crawl(self) -> None:
+        items = self.iter_items()
+        logger.info("Found %d Fluid Topics items", len(items))
+
+        indexed_ids = set()
+        if self.tracker and not self.cfg.vectara.get("reindex", False):
+            indexed_ids = self.tracker.get_indexed_ids()
+
+        delay = 1.0 / self.num_per_second
+        total_indexed = 0
+        total_failed = 0
+        total_skipped = 0
+
+        for item in items:
+            self.check_shutdown()
+            item_id = _get_first_path(item, self.id_paths, None)
+            if item_id is None:
+                logger.warning("Skipping Fluid Topics item with no configured id path: %s", item)
+                total_skipped += 1
+                continue
+
+            doc_id = f"fluid-topics-{_safe_doc_id(item_id)}"
+            title = _str_or_empty(_get_first_path(item, self.title_paths, item_id))
+
+            if doc_id in indexed_ids:
+                total_skipped += 1
+                continue
+
+            try:
+                content_record = self._fetch_content_record(item, _str_or_empty(item_id))
+                text = self._extract_text(item, content_record)
+                if not text:
+                    logger.info("Fluid Topics item %s has no extractable text, skipping", item_id)
+                    total_skipped += 1
+                    if self.tracker:
+                        self.tracker.track_skipped(doc_id, title=title, reason="No content")
+                    continue
+
+                metadata = self._build_metadata(item, content_record, _str_or_empty(item_id), title)
+                succeeded = self.indexer.index_segments(
+                    doc_id=doc_id,
+                    texts=[text],
+                    titles=[title] if title else None,
+                    doc_metadata=metadata,
+                    doc_title=title,
+                )
+
+                if succeeded:
+                    total_indexed += 1
+                    if self.tracker:
+                        self.tracker.track_indexed(doc_id, title=title)
+                else:
+                    total_failed += 1
+                    if self.tracker:
+                        self.tracker.track_failed(doc_id, title=title, error="Indexing failed")
+            except Exception as e:
+                logger.warning("Failed to process Fluid Topics item %s: %s", item_id, e)
+                total_failed += 1
+                if self.tracker:
+                    self.tracker.track_failed(doc_id, title=title, error=str(e))
+
+            if delay > 0:
+                time.sleep(delay)
+
+        logger.info(
+            "Fluid Topics crawl complete: indexed=%d failed=%d skipped=%d",
+            total_indexed, total_failed, total_skipped,
+        )
+
+
+class _DefaultFormatDict(dict):
+    """Keep unknown endpoint-template placeholders visible instead of raising KeyError."""
+
+    def __missing__(self, key):
+        return "{" + key + "}"

--- a/docs/fluidtopics-setup.md
+++ b/docs/fluidtopics-setup.md
@@ -1,0 +1,106 @@
+# Fluid Topics crawler setup
+
+The Fluid Topics crawler pulls content from a Fluid Topics tenant, extracts text
+from HTML/XML/DITA-like payloads, maps metadata for filtering/access control, and
+indexes structured documents into Vectara.
+
+Fluid Topics tenant API shapes can vary by deployment/version, so the crawler is
+configuration-driven: endpoint paths, JSON paths, pagination parameters, and the
+API-key header are all configurable.
+
+## Configuration
+
+Start from the sample config:
+
+```bash
+cp config/fluidtopics.yaml config/my-fluidtopics.yaml
+```
+
+Set the Vectara corpus key and the tenant-specific Fluid Topics settings:
+
+```yaml
+vectara:
+  corpus_key: my-fluidtopics-corpus
+  reindex: false
+  mask_pii: true       # optional; uses existing Presidio support
+
+crawling:
+  crawler_type: fluidtopics
+
+fluidtopics_crawler:
+  base_url: "https://<tenant>.fluidtopics.net"
+  api_key_header: "X-FluidTopics-Api-Key"
+  search_endpoint: "/api/search"
+  content_endpoint_template: "/api/topics/{id}"
+
+  query: "*"
+  page_param: "page"
+  page_size_param: "limit"
+  page_size: 100
+
+  id_paths: ["id", "khubId", "contentId", "topicId", "mapId"]
+  title_paths: ["title", "name", "metadata.title"]
+  content_paths: ["content", "body", "html", "xml", "dita", "data.content"]
+  metadata_paths:
+    device_family: "metadata.device_family"
+    content_type: "metadata.content_type"
+    version: "metadata.version"
+    access_tier: "metadata.access_tier"
+    publication_date: "metadata.publication_date"
+```
+
+Keep secrets in `secrets.toml`:
+
+```toml
+[altera-fluidtopics]
+api_key="<VECTARA_INDEXING_API_KEY>"
+FLUIDTOPICS_API_KEY="<FLUID_TOPICS_API_KEY>"
+# or: FLUID_TOPICS_API_KEY="<FLUID_TOPICS_API_KEY>"
+```
+
+Run:
+
+```bash
+bash run.sh config/my-fluidtopics.yaml altera-fluidtopics
+```
+
+## Incremental refresh
+
+The first implementation supports full/poll-style runs. If the tenant list API
+supports a modified-since filter, set `since_param` and `since`:
+
+```yaml
+fluidtopics_crawler:
+  since_param: "modifiedSince"
+  since: "2026-01-01T00:00:00Z"
+```
+
+Webhook-triggered incremental updates can invoke the same job with a narrowed
+query/filter once the tenant's webhook payload and update API are confirmed.
+
+## Metadata and access control
+
+By default, the crawler emits:
+
+- `source: fluid-topics`
+- `document_id`
+- `title`
+- `url` when present
+- configured metadata paths such as `device_family`, `content_type`, `version`,
+  `access_tier`, and `publication_date`
+
+Access-control rules (for example MyAltera/Azure AD groups to `access_tier`
+filters) are tenant-specific. Configure the metadata paths/static metadata to
+match the taxonomy and apply the corresponding filters at query time.
+
+## Altera / tenant dependencies
+
+Confirm these before production runs:
+
+1. Tenant base URL and API reference/version.
+2. API-key header name and whether the value must be raw or `Bearer <token>`.
+3. Search/list endpoint, pagination params, and result JSON path.
+4. Content endpoint and content/body JSON path.
+5. Metadata taxonomy and access-control mapping.
+6. Tenant rate limits and whether modified-since or webhook updates are
+   available.

--- a/ingest.py
+++ b/ingest.py
@@ -80,7 +80,7 @@ def reset_corpus_apikey(endpoint: str, corpus_key: str, api_key: str) -> None:
     Args:
         endpoint (str): Endpoint for the Vectara API.
         appclient_id (str): ID of the Vectara app client.
-        appclient_secret (str): Secret key for the Vectara app client.
+        appclient_secret (str): Secret key for the Vectara API.
         corpus_key (str): Corpus key of the Vectara corpus to index to.
     """
     url = f"{endpoint}/v2/corpora/{corpus_key}/reset"
@@ -102,7 +102,7 @@ def create_corpus_oauth(endpoint: str, corpus_key: str, auth_url: str, auth_id: 
     Args:
         endpoint (str): Endpoint for the Vectara API.
         appclient_id (str): ID of the Vectara app client.
-        appclient_secret (str): Secret key for the Vectara app client.
+        appclient_secret (str): Secret key for the Vectara API.
         corpus_key (str): Corpus key of the Vectara corpus to create
     """
     url = f"{endpoint}/v2/corpora"
@@ -235,6 +235,12 @@ def update_environment(cfg: DictConfig, source: str, env_dict) -> None:
             continue
         if k.startswith('WOLKEN_'):
             update_omega_conf(cfg, reason, f'wolken_crawler.{k[7:].lower()}', v)
+            continue
+        if k.startswith('FLUIDTOPICS_'):
+            update_omega_conf(cfg, reason, f'fluidtopics_crawler.{k[12:].lower()}', v)
+            continue
+        if k.startswith('FLUID_TOPICS_'):
+            update_omega_conf(cfg, reason, f'fluidtopics_crawler.{k[13:].lower()}', v)
             continue
 
         patterns = {

--- a/tests/test_fluidtopics_crawler.py
+++ b/tests/test_fluidtopics_crawler.py
@@ -1,0 +1,161 @@
+import sys
+import importlib.machinery
+import unittest
+from unittest.mock import MagicMock, patch
+
+for mod in ["cairosvg", "whisper", "pdf2image"]:
+    sys.modules.setdefault(mod, MagicMock())
+_playwright_mock = MagicMock()
+_playwright_mock.__spec__ = importlib.machinery.ModuleSpec("playwright", None)
+sys.modules.setdefault("playwright", _playwright_mock)
+sys.modules.setdefault("playwright.sync_api", MagicMock())
+
+from omegaconf import OmegaConf
+
+from crawlers.fluidtopics_crawler import (
+    FluidtopicsCrawler,
+    _clean_markup,
+    _get_path,
+    _safe_doc_id,
+    _str_or_empty,
+)
+
+
+def _make_crawler(**crawler_overrides):
+    cfg = OmegaConf.create({
+        "vectara": {"reindex": False},
+        "fluidtopics_crawler": {
+            "base_url": "https://docs.example.fluidtopics.net",
+            "api_key": "ft-key",
+            "api_key_header": "X-Api-Key",
+            "search_endpoint": "/api/search",
+            "content_endpoint_template": "/api/topics/{id}",
+            "page_size": 2,
+            "num_per_second": 100000,
+            "metadata_paths": {
+                "device_family": "metadata.device_family",
+                "access_tier": "acl.tier",
+            },
+        },
+    })
+    for key, value in crawler_overrides.items():
+        cfg.fluidtopics_crawler[key] = value
+
+    with patch("crawlers.fluidtopics_crawler.Crawler.__init__", return_value=None):
+        crawler = FluidtopicsCrawler.__new__(FluidtopicsCrawler)
+        crawler.cfg = cfg
+        crawler.indexer = MagicMock()
+        crawler.tracker = None
+        crawler.shutdown_requested = False
+        crawler.verbose = False
+        FluidtopicsCrawler.__init__(crawler, cfg, "https://api.vectara.io", "corpus", "vectara-key")
+    return crawler
+
+
+class TestFluidTopicsHelpers(unittest.TestCase):
+
+    def test_get_path_reads_nested_dict_and_list(self):
+        data = {"a": {"b": [{"c": "value"}]}}
+        self.assertEqual(_get_path(data, "a.b.0.c"), "value")
+        self.assertIsNone(_get_path(data, "a.b.1.c"))
+
+    def test_clean_markup_handles_html_and_plain_text(self):
+        self.assertIn("Hello", _clean_markup("<p>Hello <b>world</b></p>"))
+        self.assertEqual(_clean_markup("  Plain   text "), "Plain text")
+
+    def test_safe_doc_id_and_str_or_empty(self):
+        self.assertEqual(_safe_doc_id("Topic 123/ABC"), "Topic-123-ABC")
+        self.assertEqual(_str_or_empty(None), "")
+        self.assertEqual(_str_or_empty(0), "0")
+
+
+class TestFluidTopicsCrawler(unittest.TestCase):
+
+    def test_headers_support_raw_api_key(self):
+        crawler = _make_crawler()
+        headers = crawler._headers()
+        self.assertEqual(headers["X-Api-Key"], "ft-key")
+
+    def test_headers_support_auth_scheme(self):
+        crawler = _make_crawler(api_key_header="Authorization", auth_scheme="Bearer")
+        self.assertEqual(crawler._headers()["Authorization"], "Bearer ft-key")
+
+    def test_iter_items_paginates_until_short_page(self):
+        crawler = _make_crawler()
+        responses = [
+            {"results": [{"id": "1"}, {"id": "2"}]},
+            {"results": [{"id": "3"}]},
+        ]
+        crawler._request = MagicMock(side_effect=responses)
+
+        items = crawler.iter_items()
+
+        self.assertEqual([i["id"] for i in items], ["1", "2", "3"])
+        self.assertEqual(crawler._request.call_count, 2)
+        self.assertEqual(crawler._request.call_args_list[0].kwargs["params"]["page"], 0)
+        self.assertEqual(crawler._request.call_args_list[1].kwargs["params"]["page"], 1)
+
+    def test_build_metadata_merges_item_and_content_paths(self):
+        crawler = _make_crawler(static_metadata={"tenant": "altera"})
+        item = {"id": "t1", "metadata": {"device_family": "Agilex"}}
+        content = {"acl": {"tier": "public"}, "url": "https://reader/t1"}
+
+        metadata = crawler._build_metadata(item, content, "t1", "Title")
+
+        self.assertEqual(metadata["source"], "fluid-topics")
+        self.assertEqual(metadata["document_id"], "t1")
+        self.assertEqual(metadata["device_family"], "Agilex")
+        self.assertEqual(metadata["access_tier"], "public")
+        self.assertEqual(metadata["url"], "https://reader/t1")
+        self.assertEqual(metadata["tenant"], "altera")
+
+    def test_crawl_indexes_content(self):
+        crawler = _make_crawler()
+        crawler.iter_items = MagicMock(return_value=[{
+            "id": "topic-1",
+            "title": "Getting started",
+            "metadata": {"device_family": "Agilex"},
+        }])
+        crawler._fetch_content_record = MagicMock(return_value={
+            "content": "<topic><p>Install Quartus first.</p></topic>",
+            "acl": {"tier": "public"},
+        })
+        crawler.indexer.index_segments = MagicMock(return_value=True)
+
+        crawler.crawl()
+
+        crawler.indexer.index_segments.assert_called_once()
+        kwargs = crawler.indexer.index_segments.call_args.kwargs
+        self.assertEqual(kwargs["doc_id"], "fluid-topics-topic-1")
+        self.assertEqual(kwargs["doc_title"], "Getting started")
+        self.assertIn("Install Quartus first", kwargs["texts"][0])
+        self.assertEqual(kwargs["doc_metadata"]["access_tier"], "public")
+
+    def test_crawl_skips_items_with_no_content(self):
+        crawler = _make_crawler()
+        crawler.iter_items = MagicMock(return_value=[{"id": "empty", "title": "Empty"}])
+        crawler._fetch_content_record = MagicMock(return_value={"content": ""})
+        crawler.indexer.index_segments = MagicMock(return_value=True)
+
+        crawler.crawl()
+
+        crawler.indexer.index_segments.assert_not_called()
+
+
+class TestFluidTopicsSecretsMapping(unittest.TestCase):
+
+    def test_fluidtopics_prefix_maps_to_crawler_config(self):
+        from ingest import update_environment
+
+        cfg = OmegaConf.create({"vectara": {}, "fluidtopics_crawler": {}})
+        update_environment(cfg, "test", {
+            "FLUIDTOPICS_API_KEY": "secret",
+            "FLUID_TOPICS_BASE_URL": "https://docs.example.fluidtopics.net",
+        })
+
+        self.assertEqual(cfg.fluidtopics_crawler.api_key, "secret")
+        self.assertEqual(cfg.fluidtopics_crawler.base_url, "https://docs.example.fluidtopics.net")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a first-pass Fluid Topics connector to `vectara-ingest` for SaaS-managed ingestion of Fluid Topics tenant content into Vectara.

## Changes

- Added `crawlers/fluidtopics_crawler.py`
  - Configurable API-key header auth (`X-FluidTopics-Api-Key`, `Authorization: Bearer`, etc.)
  - Configurable search/list endpoint, content endpoint template, pagination params, JSON paths, and metadata mapping
  - Extracts HTML/XML/DITA-like content to text and indexes structured documents via `indexer.index_segments`
  - Emits metadata for filtering/access control (`source`, `document_id`, `title`, `url`, configured fields like `device_family`, `content_type`, `version`, `access_tier`, `publication_date`)
  - Supports source throttling, 429 retry-after handling, crawl tracker skip/failure accounting, and existing `vectara.mask_pii` normalization path
- Added `config/fluidtopics.yaml` sample config
- Added `docs/fluidtopics-setup.md` setup/ops notes, incremental refresh guidance, and Altera dependency checklist
- Added secret/env mapping for `FLUIDTOPICS_*` and `FLUID_TOPICS_*` keys in `ingest.py`
- Added unit coverage in `tests/test_fluidtopics_crawler.py`

## Assumptions

- Fluid Topics tenant API paths/response schemas vary; this PR intentionally keeps endpoint and JSON-path details configurable until Altera confirms their tenant contract.
- Webhook incremental sync is not implemented yet; full/poll-style runs and modified-since params are supported where the tenant API exposes them.
- Tenant-specific ACL semantics are represented as metadata; query-time filters must be configured separately based on Altera taxonomy/rules.

## Tests

- Added unit tests for helper extraction, auth headers, pagination, metadata mapping, crawl indexing/skipping, and secrets mapping.
- Not run in this environment (no local test runner access via automation).