### PR TITLE
deps: bump crawler dependencies to fix 2026-06 CVEs

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -64,11 +64,11 @@ openpyxl==3.1.5
 python-calamine==0.6.2
 tweepy==4.14.0
 matplotlib==3.8.4
-cryptography==46.0.7
+cryptography==48.0.1
 python-pptx==1.0.2
 python-docx==1.1.2
 Pillow==12.2.0
-docling==2.77.0
+docling==2.94.0
 easyocr>=1.7.0
 llama-parse==0.6.68
 llama-cloud-services==0.6.68
@@ -87,11 +87,15 @@ aiohttp>=3.13.3
 pdfminer.six>=20251230
 protobuf>=5.29.6
 urllib3>=2.7.0
-python-multipart>=0.0.27
+python-multipart>=0.0.30
 pyasn1>=0.6.3
 pyjwt>=2.12.0
 pyopenssl>=26.0.0
 onnx>=1.21.0
-tornado>=6.5.5
+tornado>=6.5.6
 jaraco-context>=6.1.0
 wheel>=0.46.2
+# Transitive pins to pull in CVE fixes (see CVE-2026-44209, CVE-2026-44019/44023):
+# banks via llama-index-core; docling-core via docling.
+banks>=2.4.2
+docling-core>=2.74.1

--- a/requirements.in
+++ b/requirements.in
@@ -78,7 +78,7 @@ pypdf >= 3.0.0
 furl==2.1.3
 office365-rest-python-client==2.6.2
 cairosvg==2.9.0
-scrapy==2.14.2
+scrapy==2.16.0
 typer==0.15.4
 boxsdk[jwt]==3.10.0
 google-cloud-aiplatform==1.133.0
@@ -95,7 +95,9 @@ onnx>=1.21.0
 tornado>=6.5.6
 jaraco-context>=6.1.0
 wheel>=0.46.2
-# Transitive pins to pull in CVE fixes (see CVE-2026-44209, CVE-2026-44019/44023):
-# banks via llama-index-core; docling-core via docling.
+# Transitive pins to pull in CVE fixes (see CVE-2026-44209, CVE-2026-44019/44023,
+# CVE-2026-42304): banks via llama-index-core; docling-core via docling;
+# twisted via scrapy.
 banks>=2.4.2
 docling-core>=2.74.1
+twisted>=26.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1109,7 +1109,7 @@ scipy==1.15.3
     #   unstructured-inference
 scramp==1.4.5
     # via pg8000
-scrapy==2.14.2
+scrapy==2.16.0
     # via -r requirements.in
 sec-downloader==0.12.2
     # via -r requirements.in
@@ -1272,8 +1272,10 @@ triton==3.3.1 ; (platform_machine == 'x86_64' and sys_platform == 'linux') or sy
     #   torch
 tweepy==4.14.0
     # via -r requirements.in
-twisted==24.11.0
-    # via scrapy
+twisted==26.4.0
+    # via
+    #   -r requirements.in
+    #   scrapy
 typer==0.15.4
     # via
     #   -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 #    uv pip compile requirements.in -o requirements.txt --universal --python-version 3.11
 accelerate==1.7.0
     # via
-    #   docling
     #   docling-ibm-models
+    #   docling-slim
     #   transformers
     #   unstructured-inference
 aiofiles==24.1.0
@@ -57,12 +57,14 @@ backoff==2.2.1
     # via unstructured
 backports-tarfile==1.2.0 ; python_full_version < '3.12'
     # via jaraco-context
-banks==2.2.0
-    # via llama-index-core
+banks==2.4.3
+    # via
+    #   -r requirements.in
+    #   llama-index-core
 beautifulsoup4==4.12.3
     # via
     #   -r requirements.in
-    #   docling
+    #   docling-slim
     #   goose3
     #   nbconvert
     #   unstructured
@@ -85,7 +87,7 @@ cairosvg==2.9.0
 certifi==2025.4.26
     # via
     #   -r requirements.in
-    #   docling
+    #   docling-slim
     #   httpcore
     #   httpx
     #   llama-cloud
@@ -105,7 +107,6 @@ click==8.1.8
     #   -r requirements.in
     #   llama-cloud-services
     #   nltk
-    #   ocrmac
     #   python-oxmsg
     #   ray
     #   typer
@@ -123,7 +124,7 @@ constantly==23.10.4
     # via twisted
 contourpy==1.3.2
     # via matplotlib
-cryptography==46.0.7
+cryptography==48.0.1
     # via
     #   -r requirements.in
     #   authlib
@@ -156,8 +157,8 @@ datasets==3.6.0
 defusedxml==0.7.1
     # via
     #   cairosvg
-    #   docling
     #   docling-core
+    #   docling-slim
     #   nbconvert
     #   scrapy
 deprecated==1.2.18
@@ -178,16 +179,19 @@ distro==1.9.0
     #   anthropic
     #   google-genai
     #   openai
-docling==2.77.0
+docling==2.94.0
     # via -r requirements.in
-docling-core==2.69.0
+docling-core==2.84.0
     # via
-    #   docling
+    #   -r requirements.in
     #   docling-ibm-models
     #   docling-parse
-docling-ibm-models==3.12.0
-    # via docling
+    #   docling-slim
+docling-ibm-models==3.13.3
+    # via docling-slim
 docling-parse==5.5.0
+    # via docling-slim
+docling-slim==2.94.0
     # via docling
 docopt==0.6.2
     # via
@@ -223,7 +227,8 @@ filelock==3.18.0
     #   transformers
 filetype==1.2.0
     # via
-    #   docling
+    #   banks
+    #   docling-slim
     #   llama-index-core
     #   unstructured
 flatbuffers==25.2.10
@@ -341,6 +346,7 @@ httplib2==0.22.0
 httpx==0.28.1
     # via
     #   anthropic
+    #   docling-slim
     #   google-genai
     #   llama-cloud
     #   llama-index-core
@@ -352,8 +358,8 @@ huggingface-hub==0.34.4
     # via
     #   accelerate
     #   datasets
-    #   docling
     #   docling-ibm-models
+    #   docling-slim
     #   timm
     #   tokenizers
     #   transformers
@@ -459,7 +465,7 @@ llvmlite==0.47.0
 lxml==6.1.0
     # via
     #   -r requirements.in
-    #   docling
+    #   docling-slim
     #   goose3
     #   justext
     #   lxml-html-clean
@@ -476,7 +482,7 @@ markdown==3.8.2
 markdown-it-py==3.0.0
     # via rich
 marko==2.1.3
-    # via docling
+    # via docling-slim
 markupsafe==3.0.2
     # via
     #   jinja2
@@ -502,7 +508,7 @@ mpire==2.10.2
     # via semchunk
 mpmath==1.3.0
     # via sympy
-msal==1.32.3
+msal==1.37.0
     # via office365-rest-python-client
 msgpack==1.1.0
     # via ray
@@ -570,6 +576,7 @@ numpy==2.4.4
     #   contourpy
     #   datasets
     #   docling-ibm-models
+    #   docling-slim
     #   easyocr
     #   imageio
     #   llama-index-core
@@ -634,8 +641,6 @@ oauthlib==3.2.2
     # via
     #   requests-oauthlib
     #   tweepy
-ocrmac==1.0.1 ; sys_platform == 'darwin'
-    # via docling
 office365-rest-python-client==2.6.2
     # via -r requirements.in
 olefile==0.47
@@ -667,7 +672,7 @@ opencv-python-headless==4.11.0.86
 openpyxl==3.1.5
     # via
     #   -r requirements.in
-    #   docling
+    #   docling-slim
 opentelemetry-api==1.40.0
     # via
     #   opentelemetry-exporter-otlp-proto-http
@@ -746,7 +751,6 @@ pandas==2.2.2
     # via
     #   -r requirements.in
     #   datasets
-    #   docling
     #   docling-core
     #   gmft
     #   unstructured-inference
@@ -779,17 +783,16 @@ pillow==12.2.0
     # via
     #   -r requirements.in
     #   cairosvg
-    #   docling
     #   docling-core
     #   docling-ibm-models
     #   docling-parse
+    #   docling-slim
     #   easyocr
     #   gmft
     #   goose3
     #   imageio
     #   llama-index-core
     #   matplotlib
-    #   ocrmac
     #   pdf2image
     #   pi-heif
     #   pikepdf
@@ -808,9 +811,9 @@ platformdirs==4.3.8
 playwright==1.56.0
     # via -r requirements.in
 pluggy==1.6.0
-    # via docling
+    # via docling-slim
 polyfactory==2.22.2
-    # via docling
+    # via docling-slim
 propcache==0.3.1
     # via
     #   aiohttp
@@ -870,10 +873,10 @@ pydantic==2.11.5
     # via
     #   anthropic
     #   banks
-    #   docling
     #   docling-core
     #   docling-ibm-models
     #   docling-parse
+    #   docling-slim
     #   google-cloud-aiplatform
     #   google-genai
     #   llama-cloud
@@ -886,8 +889,10 @@ pydantic==2.11.5
     #   unstructured-client
 pydantic-core==2.33.2
     # via pydantic
-pydantic-settings==2.9.1
-    # via docling
+pydantic-settings==2.14.2
+    # via
+    #   docling-core
+    #   docling-slim
 pydispatcher==2.0.7 ; platform_python_implementation == 'CPython'
     # via scrapy
 pydub==0.25.1
@@ -905,26 +910,9 @@ pyjwt==2.12.1
     #   boxsdk
     #   msal
 pylatexenc==2.10
-    # via docling
+    # via docling-slim
 pymysql==1.1.1
     # via -r requirements.in
-pyobjc-core==12.1 ; sys_platform == 'darwin'
-    # via
-    #   pyobjc-framework-cocoa
-    #   pyobjc-framework-coreml
-    #   pyobjc-framework-quartz
-    #   pyobjc-framework-vision
-pyobjc-framework-cocoa==12.1 ; sys_platform == 'darwin'
-    # via
-    #   pyobjc-framework-coreml
-    #   pyobjc-framework-quartz
-    #   pyobjc-framework-vision
-pyobjc-framework-coreml==12.1 ; sys_platform == 'darwin'
-    # via pyobjc-framework-vision
-pyobjc-framework-quartz==12.1 ; sys_platform == 'darwin'
-    # via pyobjc-framework-vision
-pyobjc-framework-vision==12.1 ; sys_platform == 'darwin'
-    # via ocrmac
 pyopenssl==26.2.0
     # via
     #   -r requirements.in
@@ -940,7 +928,7 @@ pypdf==5.6.0
     #   unstructured-client
 pypdfium2==4.30.0
     # via
-    #   docling
+    #   docling-slim
     #   gmft
     #   unstructured-inference
 pypydispatcher==2.1.2 ; platform_python_implementation == 'PyPy'
@@ -973,7 +961,7 @@ python-dateutil==2.8.2
 python-docx==1.1.2
     # via
     #   -r requirements.in
-    #   docling
+    #   docling-slim
 python-dotenv==1.0.1
     # via
     #   -r requirements.in
@@ -985,7 +973,7 @@ python-magic==0.4.27
     # via
     #   -r requirements.in
     #   unstructured
-python-multipart==0.0.27
+python-multipart==0.0.32
     # via
     #   -r requirements.in
     #   unstructured-inference
@@ -994,7 +982,7 @@ python-oxmsg==0.0.2
 python-pptx==1.0.2
     # via
     #   -r requirements.in
-    #   docling
+    #   docling-slim
 python-slugify==8.0.1
     # via -r requirements.in
 pytube==15.0.0
@@ -1030,8 +1018,8 @@ rapidfuzz==3.13.0
     # via
     #   unstructured
     #   unstructured-inference
-rapidocr==3.7.0
-    # via docling
+rapidocr==3.9.0
+    # via docling-slim
 ray==2.55.0
     # via -r requirements.in
 referencing==0.36.2
@@ -1048,7 +1036,7 @@ requests==2.32.3
     #   -r requirements.in
     #   boxsdk
     #   datasets
-    #   docling
+    #   docling-slim
     #   google-api-core
     #   google-auth
     #   google-cloud-bigquery
@@ -1089,7 +1077,9 @@ requests-toolbelt==1.0.0
     #   boxsdk
     #   unstructured-client
 rich==14.0.0
-    # via typer
+    # via
+    #   docling-slim
+    #   typer
 rpds-py==0.25.1
     # via
     #   jsonschema
@@ -1098,8 +1088,8 @@ rsa==4.9.1
     # via google-auth
 rtree==1.4.0
     # via
-    #   docling
     #   docling-ibm-models
+    #   docling-slim
 s3transfer==0.16.0
     # via boto3
 safetensors==0.6.2
@@ -1113,7 +1103,7 @@ scikit-image==0.26.0
     # via easyocr
 scipy==1.15.3
     # via
-    #   docling
+    #   docling-slim
     #   easyocr
     #   scikit-image
     #   unstructured-inference
@@ -1214,6 +1204,7 @@ torch==2.7.1
     #   -r requirements.in
     #   accelerate
     #   docling-ibm-models
+    #   docling-slim
     #   easyocr
     #   effdet
     #   gmft
@@ -1227,18 +1218,19 @@ torchvision==0.22.1
     # via
     #   -r requirements.in
     #   docling-ibm-models
+    #   docling-slim
     #   easyocr
     #   effdet
     #   timm
-tornado==6.5.5
+tornado==6.5.7
     # via
     #   -r requirements.in
     #   jupyter-client
 tqdm==4.67.1
     # via
     #   datasets
-    #   docling
     #   docling-ibm-models
+    #   docling-slim
     #   huggingface-hub
     #   llama-index-core
     #   mpire
@@ -1285,8 +1277,8 @@ twisted==24.11.0
 typer==0.15.4
     # via
     #   -r requirements.in
-    #   docling
     #   docling-core
+    #   docling-slim
 typing-extensions==4.14.0
     # via
     #   aiosignal
@@ -1367,7 +1359,9 @@ webencodings==0.5.1
     #   html5lib
     #   tinycss2
 websockets==16.0
-    # via google-genai
+    # via
+    #   docling-slim
+    #   google-genai
 wheel==0.46.3
     # via -r requirements.in
 wrapt==1.17.2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -536,6 +536,7 @@ class TestUtils(unittest.TestCase):
         """Test logging setup with default level."""
         mock_root_logger = Mock()
         mock_root_logger.handlers = []  # Empty handlers list to trigger handler setup
+        mock_root_logger.filters = []  # Iterable so the pdfminer filter check works
         mock_get_logger.return_value = mock_root_logger
         mock_handler_instance = Mock()
         mock_handler.return_value = mock_handler_instance
@@ -551,6 +552,7 @@ class TestUtils(unittest.TestCase):
     def test_setup_logging_env_level(self, mock_get_logger):
         """Test logging setup with environment variable."""
         mock_root_logger = Mock()
+        mock_root_logger.filters = []  # Iterable so the pdfminer filter check works
         mock_get_logger.return_value = mock_root_logger
         
         with patch('logging.StreamHandler'):


### PR DESCRIPTION
## What

Bumps Python dependencies to close the high-severity CVEs flagged in the `gto-eese-crawlers` image scan (`2026.06.14-fe892e3212-59`).

| CVE | Package | Before → After | Pin |
|---|---|---|---|
| GHSA-537c-gmf6-5ccf | cryptography | 46.0.7 → 48.0.1 | direct |
| CVE-2026-44017 / 47214 | docling | 2.77.0 → 2.94.0 | direct |
| CVE-2026-44019 / 44023 | docling-core | 2.69.0 → 2.84.0 | transitive (constraint) |
| CVE-2026-53539 | python-multipart | 0.0.27 → 0.0.32 | direct |
| CVE-2026-49853 / 49855 | tornado | 6.5.5 → 6.5.7 | direct |
| CVE-2026-44209 | banks | 2.2.0 → 2.4.3 | transitive (constraint) |
| CVE-2026-42304 | twisted | 24.11.0 → 26.4.0 | transitive (constraint) |
| — (required for twisted) | scrapy | 2.14.2 → 2.16.0 | direct |
| CVE-2026-44432 | urllib3 | already 2.7.0 | — (no change) |

Transitive packages (`docling-core`, `banks`, `twisted`) are pinned with constraints in `requirements.in`. Lock regenerated with `uv pip compile` (the Makefile's command).

### Note on twisted / scrapy

Twisted 26.4.0 (final) is on PyPI, but `scrapy==2.14.2` caps twisted at `<=25.5.0`. `scrapy==2.16.0` drops the upper bound (`twisted>=21.7.0`), so scrapy is bumped `2.14.2 → 2.16.0` to take twisted 26.4.0. **This makes scrapy a behavioral change, not just a security patch** — the website/docs crawler discovery path runs on scrapy, so it needs a crawl smoke test before merge.

## Testing notes

- `uv pip compile` resolves cleanly (exit 0); CI `test (3.11)` is green.
- Docker image builds successfully; all bumped packages install at the expected versions and import cleanly (incl. the scrapy↔twisted reactor wiring).
- docling 2.77→2.94: parsed a real 21-page PDF end-to-end — `ConversionStatus.SUCCESS`, ~48k chars extracted.
- scrapy 2.14→2.16 + twisted 24→26: ran the real `LinkSpider` discovery path against a live site — 48 URLs followed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)