### PR TITLE
deps: bump msgpack 1.1.0 → 1.2.1 (crawlers CVE)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -97,7 +97,8 @@ jaraco-context>=6.1.0
 wheel>=0.46.2
 # Transitive pins to pull in CVE fixes (see CVE-2026-44209, CVE-2026-44019/44023,
 # CVE-2026-42304): banks via llama-index-core; docling-core via docling;
-# twisted via scrapy.
+# twisted via scrapy; msgpack via ray.
 banks>=2.4.2
 docling-core>=2.74.1
 twisted>=26.4.0
+msgpack>=1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -510,8 +510,10 @@ mpmath==1.3.0
     # via sympy
 msal==1.37.0
     # via office365-rest-python-client
-msgpack==1.1.0
-    # via ray
+msgpack==1.2.1
+    # via
+    #   -r requirements.in
+    #   ray
 multidict==6.4.4
     # via
     #   aiohttp


### PR DESCRIPTION
## What

Follow-up to #352. The latest `crawlers` image scan flagged one additional **Python** dependency CVE not covered by #352:

| Package | Before → After | Sev | CVEs |
|---|---|---|---|
| msgpack | 1.1.0 → 1.2.1 | High | 1 |

`msgpack` is transitive via `ray`; pinned with a constraint (`msgpack>=1.2.1`) in `requirements.in`, lock regenerated with `uv pip compile`. `ray` accepts the new version — resolution is clean and no other pins shifted (diff is msgpack-only).

## Out of scope (not in this repo's `requirements.txt`)

The remaining rows in the crawlers scan are not Python deps and aren't fixable here:
- **log4j-core** (2.25.3 → 2.25.4) and **jackson-databind** (2.18.6 → 2.18.8) — bundled Java components.
- **openssl (ubuntu)** (3.0.13-0ubuntu3.9 → …3.11) — base image; fixed by rebuild/`apt upgrade`.

With this + #352, **every Python dependency CVE in the crawlers scan is addressed.**

## Testing

- `uv pip compile` resolves cleanly (exit 0); diff is limited to the msgpack bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)