### PR TITLE
fix: index add_image_bytes documents as core, not structured

### DIFF
--- a/core/image_processor.py
+++ b/core/image_processor.py
@@ -128,7 +128,7 @@ class ImageProcessor:
                 try:
                     image_binary = self._read_renderable_image_bytes(local_path, is_svg)
                 except Exception as e:
-                    logger.info(f"Failed to rasterize SVG image {image_url} from {url}: {e}, skipping")
+                    logger.info(f"Failed to read image {image_url} from {url}: {e}, skipping")
                     continue
                 image_id = f"web_{slugify(url)}_image_{inx}"
                 image_bytes.append((image_id, image_binary))

--- a/core/image_processor.py
+++ b/core/image_processor.py
@@ -36,6 +36,20 @@ class ImageProcessor:
             )
         return self.image_summarizer
     
+    @staticmethod
+    def _read_renderable_image_bytes(local_path: str, is_svg: bool) -> bytes:
+        """Return image bytes safe to store as image_data and render as <img>.
+
+        SVG is rasterized to PNG via cairosvg — raw SVG bytes get labeled image/png by
+        the MIME sniffer's default fallback and won't decode in the browser. Raster
+        images (PNG/JPEG/...) pass through unchanged.
+        """
+        if is_svg:
+            import cairosvg
+            return cairosvg.svg2png(url=local_path)
+        with open(local_path, 'rb') as fp:
+            return fp.read()
+
     def process_web_images(self, images: List[Dict[str, str]], url: str, ex_metadata: Dict[str, Any]) -> Tuple[List[Tuple[str, str, Dict[str, Any]]], List[Tuple[str, bytes]]]:
         """
         Process images from web pages
@@ -83,7 +97,8 @@ class ImageProcessor:
                     # download as before
                     response = requests.get(image_url, headers=get_headers(self.cfg), stream=True, timeout=30)
                     if response.status_code != 200:
-                        logger.info(f"Failed to retrieve image {image_url} from {url}, skipping")
+                        logger.info(f"Failed to retrieve image {image_url} from {url} "
+                                    f"(HTTP {response.status_code} {response.reason}), skipping")
                         continue
                     # write to a temp file with appropriate extension guessed from URL path or default to .png
                     url_path = urlparse(image_url).path
@@ -99,7 +114,8 @@ class ImageProcessor:
 
                 # Skip small raster images (avatars, icons) — consistent with DoclingParser
                 # SVGs are vector and don't have inherent pixel dimensions; skip the size check for them
-                if not image_summarizer._is_svg_file(local_path, image_url):
+                is_svg = image_summarizer._is_svg_file(local_path, image_url)
+                if not is_svg:
                     from PIL import Image as _PILImage
                     with _PILImage.open(local_path) as pil_img:
                         w, h = pil_img.size
@@ -107,9 +123,13 @@ class ImageProcessor:
                         logger.debug(f"Skipping small image ({w}x{h}px) from {image_url}")
                         continue
 
-                # Store binary data
-                with open(local_path, 'rb') as fp:
-                    image_binary = fp.read()
+                # Store binary data. SVG must be rasterized to PNG (see helper) — the corpus
+                # renders image_data as <img>, and raw SVG bytes labeled image/png don't decode.
+                try:
+                    image_binary = self._read_renderable_image_bytes(local_path, is_svg)
+                except Exception as e:
+                    logger.info(f"Failed to rasterize SVG image {image_url} from {url}: {e}, skipping")
+                    continue
                 image_id = f"web_{slugify(url)}_image_{inx}"
                 image_bytes.append((image_id, image_binary))
 

--- a/core/indexer.py
+++ b/core/indexer.py
@@ -150,14 +150,16 @@ class Indexer:
         # needs no tokenizer model — safe for air-gapped deployments — and already the
         # DoclingDocumentParser default) so parts are well-sized. This also trips
         # _is_chunking_enabled() below, which forces use_core_indexing on. Only applied
-        # when chunking is off; an explicit user setting is never overridden.
+        # when chunking is off; an explicit chunking_strategy is never overridden, and
+        # unrelated docling keys (image_scale, layout_model, ...) are preserved.
         if (self.add_image_bytes and self.doc_parser == "docling"
                 and self.docling_config.get("chunking_strategy", "none") == "none"):
             self.docling_config = {
+                **self.docling_config,
                 "chunking_strategy": "hierarchical",
                 "chunk_size": self.docling_config.get("chunk_size", 1024),
             }
-            OmegaConf.update(cfg, "doc_processing.docling_config", self.docling_config, merge=False)
+            OmegaConf.update(cfg, "doc_processing.docling_config", self.docling_config, merge=True)
             logger.info(
                 "add_image_bytes is enabled: defaulting docling_config.chunking_strategy to "
                 "'hierarchical' so image-bearing documents are indexed via core with well-sized parts.")
@@ -1115,8 +1117,14 @@ class Indexer:
             updated_document_parts = []
             
             # Process each text/metadata pair to find images
-            for i, (text, metadata) in enumerate(zip(texts, metadatas)):
-                image_id = metadata.get('image_id') if metadata else None
+            for i, (raw_text, raw_metadata) in enumerate(zip(texts, metadatas)):
+                image_id = raw_metadata.get('image_id') if raw_metadata else None
+                # Mirror DocumentBuilder._build_core_document: normalize text and metadata
+                # (Unicode NFD + optional PII masking) so these rebuilt parts match every
+                # other core document instead of carrying raw/unmasked content.
+                text = self.normalize_text(raw_text)
+                metadata = ({k: self.normalize_value(v) for k, v in raw_metadata.items()}
+                            if raw_metadata else raw_metadata)
                 
                 if image_id:
                     # Find binary data for this image

--- a/core/indexer.py
+++ b/core/indexer.py
@@ -105,7 +105,27 @@ class Indexer:
         self.extract_metadata = cfg.doc_processing.get("extract_metadata", [])
         self.contextual_chunking = cfg.doc_processing.get("contextual_chunking", False)
         self.image_context = cfg.doc_processing.get("image_context", {'num_previous_chunks': 1, 'num_next_chunks': 1})
-        
+
+        # add_image_bytes attaches binary image data, which only *core* documents
+        # support (the images/document_parts fields are core-only; the structured
+        # API rejects them). Core parts are indexed as-is with no server-side
+        # chunking, so without a parser chunker the whole document would become one
+        # oversized part. Default docling chunking to 'hierarchical' (structure-based,
+        # needs no tokenizer model — safe for air-gapped deployments — and already the
+        # DoclingDocumentParser default) so parts are well-sized. This also trips
+        # _is_chunking_enabled() below, which forces use_core_indexing on. Only applied
+        # when chunking is off; an explicit user setting is never overridden.
+        if (self.add_image_bytes and self.doc_parser == "docling"
+                and self.docling_config.get("chunking_strategy", "none") == "none"):
+            self.docling_config = {
+                "chunking_strategy": "hierarchical",
+                "chunk_size": self.docling_config.get("chunk_size", 1024),
+            }
+            OmegaConf.update(cfg, "doc_processing.docling_config", self.docling_config, merge=False)
+            logger.info(
+                "add_image_bytes is enabled: defaulting docling_config.chunking_strategy to "
+                "'hierarchical' so image-bearing documents are indexed via core with well-sized parts.")
+
         # Auto-enable core indexing when chunking is detected
         if self._is_chunking_enabled():
             if not self.use_core_indexing:
@@ -690,8 +710,16 @@ class Indexer:
                 if text is None or len(text) < 3:
                     return False
 
-                # If process_locally is enabled, route web content through document parser
-                if self.process_locally:
+                # Route web content through the local document parser when configured,
+                # or when the page has images we must attach as binary data: the inline
+                # web path below always builds a *structured* document, but binary images
+                # require *core* (see add_image_bytes handling in index_segments). Routing
+                # through index_file parses the HTML with docling, so the page is chunked
+                # and the images are attached to a valid core document.
+                route_locally = self.process_locally or (
+                    self.add_image_bytes and self.summarize_images and res.get('images')
+                )
+                if route_locally:
                     temp_html_path = None
                     try:
                         # Save HTML to temporary file and process through doc parser
@@ -706,9 +734,14 @@ class Indexer:
                         # Process through index_file which uses the configured document parser.
                         # Docling misses images nested inside <p>/<li> tags — pass them
                         # via extra_image_urls so index_file can supplement with web images.
+                        # force_local_processing: the source URI (a web URL) has no file
+                        # extension, so index_file's should_process_locally() heuristic would
+                        # send the temp .html down the raw upload path (Case A), bypassing the
+                        # docling parse + image-bytes attachment we routed here for.
                         result = self.index_file(
                             temp_html_path, url, metadata, title_hint=res.get('title', ''),
-                            extra_image_urls=res.get('images', [])
+                            extra_image_urls=res.get('images', []),
+                            force_local_processing=True
                         )
                         safe_remove_file(temp_html_path)
                         return result
@@ -883,6 +916,20 @@ class Indexer:
         if image_bytes_dict and self.verbose:
             logger.info(f"Document {doc_id} has {len(image_bytes_dict)} images with binary data available for later upload")
 
+        # Binary image data (the images/document_parts fields) is only valid on *core*
+        # documents; a structured document carrying it is rejected by the API
+        # ("Unrecognized field images", and the core-only 'title'/'sections' mismatch).
+        # If we will attach image bytes below, build the document as core from the start
+        # so its shape (document_parts, no top-level title/sections) matches the type.
+        if (self.add_image_bytes and image_bytes and metadatas and not use_core_indexing
+                and any(m and m.get('image_id')
+                        and self._find_image_binary_data(m['image_id'], image_bytes_dict)
+                        for m in metadatas)):
+            logger.info(
+                f"Document {doc_id} carries binary image data (add_image_bytes); "
+                f"indexing via core instead of structured.")
+            use_core_indexing = True
+
         from core.document_builder import DocumentBuilder
         # Normalize URLs in doc_metadata
         if doc_metadata and 'url' in doc_metadata:
@@ -956,7 +1003,10 @@ class Indexer:
                         "metadata": metadata
                     })
             
-            # Update document structure if we found any images with binary data
+            # Update document structure if we found any images with binary data.
+            # use_core_indexing was already forced True above (pre-build) whenever this
+            # is non-empty, so the document was built in core shape and these core-only
+            # fields are valid.
             if images_array:
                 document["images"] = images_array
                 document["document_parts"] = updated_document_parts
@@ -988,7 +1038,8 @@ class Indexer:
         return result
 
     def index_file(self, filename: str, uri: str, metadata: Dict[str, Any], id: str = None, title_hint: str = None,
-                   extra_image_urls: Optional[List[Dict[str, str]]] = None) -> bool:
+                   extra_image_urls: Optional[List[Dict[str, str]]] = None,
+                   force_local_processing: bool = False) -> bool:
         """
         Index a local file into the Vectara corpus.
 
@@ -1002,6 +1053,11 @@ class Indexer:
                 summarize and append inline to the parent document. Used in the process_locally path
                 to include images that Docling may miss when they are nested inside <p>/<li> tags.
                 Only applied when inline_images=True and summarize_images=True.
+            force_local_processing (bool): Force the local parse path (Case B) regardless of the
+                per-file should_process_locally() heuristic. Callers use this when they already know
+                the file must be parsed locally — e.g. index_url routing a web page here to attach
+                binary image data, where the source URI has no file extension so the heuristic (which
+                keys off the URI) would otherwise send it down the raw file-upload path.
 
         Returns:
             bool: True if indexing was successful, False otherwise.
@@ -1022,7 +1078,8 @@ class Indexer:
         # (e.g. one image flips it True, then every later .txt/.md gets
         # wrongly routed to Case B and fails with "File format not allowed").
         process_locally = (
-            self.process_locally
+            force_local_processing
+            or self.process_locally
             or self.file_processor.should_process_locally(filename, uri)
         )
 

--- a/core/indexer.py
+++ b/core/indexer.py
@@ -47,10 +47,28 @@ from core.incremental import (
 )
 from core.web_extractor_base import create_web_extractor
 from core.file_processor import FileProcessor
+from core.document_builder import MAX_SECTION_CHARS
 
 # Suppress FutureWarning related to torch.load
 warnings.filterwarnings("ignore", category=FutureWarning, module="whisper")
 warnings.filterwarnings("ignore", category=UserWarning, message="FP16 is not supported on CPU; using FP32 instead")
+
+
+def _document_has_oversized_part(document: Dict[str, Any]) -> bool:
+    """True if any structured section text or bundled table exceeds MAX_SECTION_CHARS.
+
+    split_oversized only changes the document when such a part exists, so this is the
+    precise condition under which retrying a 400 with split_oversized=True can help.
+    Other 400s (e.g. an unrecognized field) have no oversized part and must fail loudly
+    rather than be silently retried into a degraded, incomplete document.
+    """
+    for section in document.get('sections', []):
+        if len(section.get('text', '')) > MAX_SECTION_CHARS:
+            return True
+        for table in section.get('tables', []):
+            if len(json.dumps(table.get('data', {}))) > MAX_SECTION_CHARS:
+                return True
+    return False
 
 
 class Indexer:
@@ -1158,8 +1176,10 @@ class Indexer:
                                      prior_fingerprint=prior_fingerprint,
                                      content_hash_override=content_hash_override)
 
-        if not result and not use_core_indexing and self._last_response_status == 400:
-            logger.info(f"Document {doc_id} failed with 400, retrying with split_oversized=True")
+        if (not result and not use_core_indexing and self._last_response_status == 400
+                and _document_has_oversized_part(document)):
+            logger.info(f"Document {doc_id} failed with an oversized-part 400, "
+                        f"retrying with split_oversized=True")
             document_retry = document_builder.build_document(
                 doc_id=doc_id,
                 texts=texts,

--- a/core/indexer.py
+++ b/core/indexer.py
@@ -862,7 +862,7 @@ class Indexer:
                         result = self.index_file(
                             temp_html_path, url, metadata, title_hint=res.get('title', ''),
                             extra_image_urls=res.get('images', []), prior_fingerprint=prior_fingerprint,
-                            content_hash_override=content_hash_from_text(text), focrce_local_processing=True
+                            content_hash_override=content_hash_from_text(text), force_local_processing=True
                         )
                         safe_remove_file(temp_html_path)
                         return result

--- a/core/indexer.py
+++ b/core/indexer.py
@@ -47,7 +47,7 @@ from core.incremental import (
 )
 from core.web_extractor_base import create_web_extractor
 from core.file_processor import FileProcessor
-from core.document_builder import MAX_SECTION_CHARS
+from core.document_builder import MAX_SECTION_CHARS, MAX_PART_SIZE
 
 # Suppress FutureWarning related to torch.load
 warnings.filterwarnings("ignore", category=FutureWarning, module="whisper")
@@ -1145,19 +1145,22 @@ class Indexer:
                         if self.verbose:
                             logger.info(f"Added binary data for image {image_id} with MIME type {mime_type}")
                     else:
-                        # No binary data found, add as regular text
-                        updated_document_parts.append({
-                            "text": text,
-                            "metadata": metadata
-                        })
+                        # No binary data found, add as regular text (split if oversized).
+                        for chunk in DocumentBuilder._split_text(text, MAX_PART_SIZE):
+                            updated_document_parts.append({
+                                "text": chunk,
+                                "metadata": metadata
+                            })
                         if self.verbose:
                             logger.warning(f"Binary data not found for image {image_id}")
                 else:
-                    # Regular text element
-                    updated_document_parts.append({
-                        "text": text,
-                        "metadata": metadata
-                    })
+                    # Regular text element — split to stay under the core part-size limit,
+                    # mirroring _build_core_document (this path bypasses build_document's split).
+                    for chunk in DocumentBuilder._split_text(text, MAX_PART_SIZE):
+                        updated_document_parts.append({
+                            "text": chunk,
+                            "metadata": metadata
+                        })
             
             # Update document structure if we found any images with binary data.
             # use_core_indexing was already forced True above (pre-build) whenever this

--- a/tests/test_add_image_bytes_core_routing.py
+++ b/tests/test_add_image_bytes_core_routing.py
@@ -84,6 +84,7 @@ class TestFix1IndexSegmentsForcesCore(unittest.TestCase):
         ix.verbose = False
         ix.store_docs = False
         ix.reindex = False
+        ix.incremental = False
         ix.static_metadata = None
         ix.add_image_bytes = True
         # Instance flag deliberately False: prove the per-call decision alone flips
@@ -130,6 +131,7 @@ class TestFix3WebRouting(unittest.TestCase):
     def _make_indexer(self, res):
         ix = Indexer.__new__(Indexer)
         ix.cfg = _base_cfg({})
+        ix.incremental = False
         ix.add_image_bytes = True
         ix.summarize_images = True
         ix.process_locally = False

--- a/tests/test_add_image_bytes_core_routing.py
+++ b/tests/test_add_image_bytes_core_routing.py
@@ -60,6 +60,22 @@ class TestFix2ChunkingDefault(unittest.TestCase):
         ix = Indexer(cfg, api_url="https://api.example.test", corpus_key="c", api_key="k")
         self.assertEqual(ix.docling_config['chunking_strategy'], 'hybrid')
 
+    def test_other_docling_keys_are_preserved(self):
+        # Defaulting chunking_strategy must not drop unrelated user-set docling keys.
+        cfg = _base_cfg({
+            'doc_parser': 'docling',
+            'add_image_bytes': True,
+            'docling_config': {'chunking_strategy': 'none', 'image_scale': 3,
+                               'do_formula_enrichment': True},
+        })
+        ix = Indexer(cfg, api_url="https://api.example.test", corpus_key="c", api_key="k")
+        self.assertEqual(ix.docling_config['chunking_strategy'], 'hierarchical')
+        self.assertEqual(ix.docling_config['image_scale'], 3)
+        self.assertTrue(ix.docling_config['do_formula_enrichment'])
+        # The shared cfg (read by the lazily-built FileProcessor) keeps them too.
+        self.assertEqual(cfg.doc_processing.docling_config.image_scale, 3)
+        self.assertTrue(cfg.doc_processing.docling_config.do_formula_enrichment)
+
     def test_no_change_without_add_image_bytes(self):
         cfg = _base_cfg({
             'doc_parser': 'docling',

--- a/tests/test_add_image_bytes_core_routing.py
+++ b/tests/test_add_image_bytes_core_routing.py
@@ -1,0 +1,192 @@
+"""Regression tests: add_image_bytes must produce *core* documents, not structured.
+
+Binary image data (the `images` / `document_parts` fields) is only valid on Vectara
+v2 *core* documents. When `add_image_bytes` is enabled, image-bearing documents were
+being sent to the *structured* endpoint, which rejects the payload with
+``UnrecognizedPropertyException: Unrecognized field "images"`` — a 400 that silently
+dropped the whole document (text + images). See the three fixes in core/indexer.py:
+
+  * Fix 1 - index_segments forces core when it attaches image bytes.
+  * Fix 2 - __init__ defaults docling chunking to 'hierarchical' under add_image_bytes,
+            which (via _is_chunking_enabled) auto-enables core indexing.
+  * Fix 3 - index_url routes image-bearing web pages through the local docling parser
+            (index_file) instead of the always-structured inline path.
+"""
+import json
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.modules.setdefault('cairosvg', MagicMock())
+
+from omegaconf import OmegaConf
+
+from core.indexer import Indexer
+
+
+def _base_cfg(doc_processing: dict) -> OmegaConf:
+    return OmegaConf.create({
+        'vectara': {'verbose': False},
+        'crawling': {'crawler_type': 'test'},
+        'doc_processing': doc_processing,
+    })
+
+
+class TestFix2ChunkingDefault(unittest.TestCase):
+    """add_image_bytes + docling + chunking 'none' -> forced to 'hierarchical' + core."""
+
+    def test_defaults_to_hierarchical_and_enables_core(self):
+        cfg = _base_cfg({
+            'doc_parser': 'docling',
+            'add_image_bytes': True,
+            'summarize_images': False,
+            'docling_config': {'chunking_strategy': 'none'},
+        })
+        ix = Indexer(cfg, api_url="https://api.example.test", corpus_key="c", api_key="k")
+
+        self.assertEqual(ix.docling_config['chunking_strategy'], 'hierarchical')
+        self.assertTrue(ix.use_core_indexing)
+        # The shared cfg must be updated too, so the lazily-built FileProcessor
+        # (which reads cfg.doc_processing.docling_config) sees the same value.
+        self.assertEqual(cfg.doc_processing.docling_config.chunking_strategy, 'hierarchical')
+
+    def test_explicit_strategy_is_not_overridden(self):
+        cfg = _base_cfg({
+            'doc_parser': 'docling',
+            'add_image_bytes': True,
+            'docling_config': {'chunking_strategy': 'hybrid', 'chunk_size': 512},
+        })
+        ix = Indexer(cfg, api_url="https://api.example.test", corpus_key="c", api_key="k")
+        self.assertEqual(ix.docling_config['chunking_strategy'], 'hybrid')
+
+    def test_no_change_without_add_image_bytes(self):
+        cfg = _base_cfg({
+            'doc_parser': 'docling',
+            'add_image_bytes': False,
+            'docling_config': {'chunking_strategy': 'none'},
+        })
+        ix = Indexer(cfg, api_url="https://api.example.test", corpus_key="c", api_key="k")
+        self.assertEqual(ix.docling_config['chunking_strategy'], 'none')
+        self.assertFalse(ix.use_core_indexing)
+
+
+class TestFix1IndexSegmentsForcesCore(unittest.TestCase):
+    """index_segments must POST type=core (not structured) when it attaches images."""
+
+    def _make_indexer(self):
+        ix = Indexer.__new__(Indexer)
+        ix.api_url = "https://api.example.test"
+        ix.corpus_key = "c"
+        ix.api_key = "k"
+        ix.x_source = "vectara-ingest-test"
+        ix.cfg = _base_cfg({})
+        ix.session = MagicMock()
+        ix.verbose = False
+        ix.store_docs = False
+        ix.reindex = False
+        ix.static_metadata = None
+        ix.add_image_bytes = True
+        # Instance flag deliberately False: prove the per-call decision alone flips
+        # the document to core purely because image bytes were attached.
+        ix.use_core_indexing = False
+        ix._init_processors = MagicMock()
+        return ix
+
+    def test_image_bytes_document_is_posted_as_core(self):
+        ix = self._make_indexer()
+        posted = MagicMock()
+        posted.status_code = 201
+        ix.session.post.return_value = posted
+
+        image_id = "web_page_image_0"
+        ok = ix.index_segments(
+            doc_id="doc1",
+            texts=["a picture of a cat"],
+            metadatas=[{'element_type': 'image', 'image_id': image_id}],
+            doc_metadata={'url': 'https://example.test/p'},
+            doc_title="Page",
+            image_bytes=[(image_id, b"\x89PNG\r\n\x1a\n stub bytes")],
+        )
+
+        self.assertTrue(ok)
+        ix.session.post.assert_called_once()
+        body = json.loads(ix.session.post.call_args.kwargs['data'])
+        self.assertEqual(body['type'], 'core')
+        self.assertIn('images', body)
+        self.assertEqual(body['images'][0]['id'], image_id)
+        # Must be built in *core* shape — not a structured/core mongrel. The API
+        # rejects a core doc that still carries the structured-only 'title'/'sections'
+        # ("body.title Unknown property"), so those must be absent and document_parts
+        # present.
+        self.assertIn('document_parts', body)
+        self.assertNotIn('sections', body)
+        self.assertNotIn('title', body)
+
+
+class TestFix3WebRouting(unittest.TestCase):
+    """index_url routes image-bearing pages through index_file (docling), and stays
+    on the fast web path when there are no images to attach."""
+
+    def _make_indexer(self, res):
+        ix = Indexer.__new__(Indexer)
+        ix.cfg = _base_cfg({})
+        ix.add_image_bytes = True
+        ix.summarize_images = True
+        ix.process_locally = False
+        ix.remove_boilerplate = False
+        ix.parse_tables = False
+        ix.remove_code = True
+        ix.detected_language = 'en'
+        ix.extract_metadata = []
+        ix.timeout = 90
+        ix.last_skip_reason = None
+        ix.verbose = False
+        ix.model_config = MagicMock()
+        ix.file_processor = MagicMock()
+        ix.file_processor.inline_images = True
+        ix.url_triggers_download = MagicMock(return_value=False)
+        ix.check_download_or_pdf = MagicMock(return_value={"type": "page"})
+        ix.fetch_page_contents = MagicMock(return_value=res)
+        ix.index_file = MagicMock(return_value=True)
+        ix.index_segments = MagicMock(return_value=True)
+        return ix
+
+    def test_page_with_images_routes_to_index_file(self):
+        res = {
+            'html': '<html><body><p>hi</p><img src="a.png"></body></html>',
+            'text': 'hi there this is a page',
+            'title': 'T',
+            'url': 'https://example.test/p',
+            'images': [{'src': 'https://example.test/a.png', 'alt': ''}],
+        }
+        ix = self._make_indexer(res)
+
+        ix.index_url('https://example.test/p', metadata={'url': 'https://example.test/p'})
+
+        ix.index_file.assert_called_once()
+        self.assertIn('extra_image_urls', ix.index_file.call_args.kwargs)
+        self.assertEqual(ix.index_file.call_args.kwargs['extra_image_urls'], res['images'])
+        # Must force local processing: the source URI has no file extension, so
+        # index_file's should_process_locally() heuristic would otherwise send the
+        # temp .html down the raw upload path and drop the image bytes.
+        self.assertTrue(ix.index_file.call_args.kwargs.get('force_local_processing'))
+        ix.index_segments.assert_not_called()
+
+    def test_page_without_images_stays_on_web_path(self):
+        res = {
+            'html': '<html><body><p>hi</p></body></html>',
+            'text': 'hi there this is a page',
+            'title': 'T',
+            'url': 'https://example.test/p',
+            # no 'images' key -> nothing to attach -> must not route to index_file
+        }
+        ix = self._make_indexer(res)
+
+        ix.index_url('https://example.test/p', metadata={'url': 'https://example.test/p'})
+
+        ix.index_file.assert_not_called()
+        ix.index_segments.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_add_image_bytes_core_routing.py
+++ b/tests/test_add_image_bytes_core_routing.py
@@ -21,6 +21,7 @@ sys.modules.setdefault('cairosvg', MagicMock())
 
 from omegaconf import OmegaConf
 
+from core.document_builder import MAX_PART_SIZE
 from core.indexer import Indexer
 
 
@@ -122,6 +123,40 @@ class TestFix1IndexSegmentsForcesCore(unittest.TestCase):
         self.assertIn('document_parts', body)
         self.assertNotIn('sections', body)
         self.assertNotIn('title', body)
+
+    def test_oversized_text_part_is_split_in_core_image_doc(self):
+        # A large text element must be split to stay under the core part-size limit,
+        # just like _build_core_document does. The image-attach path used to overwrite
+        # the split parts with unsplit ones -> "Document part text is too large" 400.
+        ix = self._make_indexer()
+        posted = MagicMock()
+        posted.status_code = 201
+        ix.session.post.return_value = posted
+
+        image_id = "web_page_image_0"
+        ok = ix.index_segments(
+            doc_id="doc1",
+            texts=["a" * (MAX_PART_SIZE + 5000), "a picture of a cat"],
+            metadatas=[
+                {'element_type': 'text'},
+                {'element_type': 'image', 'image_id': image_id},
+            ],
+            doc_metadata={'url': 'https://example.test/p'},
+            doc_title="Page",
+            image_bytes=[(image_id, b"\x89PNG\r\n\x1a\n stub bytes")],
+        )
+
+        self.assertTrue(ok)
+        body = json.loads(ix.session.post.call_args.kwargs['data'])
+        self.assertEqual(body['type'], 'core')
+        # Every part must be within the core size limit.
+        for part in body['document_parts']:
+            self.assertLessEqual(len(part['text']), MAX_PART_SIZE)
+        # The big text was actually split into multiple parts.
+        self.assertGreater(len(body['document_parts']), 2)
+        # The image part still carries its image_id and the image is attached.
+        self.assertTrue(any(p.get('image_id') == image_id for p in body['document_parts']))
+        self.assertEqual(body['images'][0]['id'], image_id)
 
 
 class TestFix3WebRouting(unittest.TestCase):

--- a/tests/test_add_image_bytes_normalization.py
+++ b/tests/test_add_image_bytes_normalization.py
@@ -1,0 +1,110 @@
+"""Regression: the add_image_bytes path must normalize text/metadata like DocumentBuilder.
+
+When add_image_bytes attaches binary image data it rebuilds `document_parts` (and the
+image `description`) from the raw `texts`/`metadatas` passed to index_segments, bypassing
+DocumentBuilder._build_core_document's normalize_text/normalize_value. That produced parts
+whose text was not Unicode-normalized (NFD) and, when cfg.vectara.mask_pii is on, not masked
+— inconsistent with every other core document. These tests pin the normalization.
+
+NFD is used as the observable, dependency-free normalization: normalize_text always applies
+unicodedata.normalize('NFD', ...) regardless of mask_pii, so a composed 'é' (U+00E9) must
+come out decomposed as 'e' + U+0301.
+"""
+import json
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.modules.setdefault('cairosvg', MagicMock())
+
+from omegaconf import OmegaConf
+
+from core.indexer import Indexer
+
+COMPOSED = "caf\u00e9"      # 'café' with a single composed é (U+00E9)
+DECOMPOSED = "cafe\u0301"    # NFD: 'cafe' + combining acute accent (U+0301)
+
+
+def _cfg() -> OmegaConf:
+    return OmegaConf.create({
+        'vectara': {'verbose': False},
+        'crawling': {'crawler_type': 'test'},
+        'doc_processing': {},
+    })
+
+
+def _make_indexer() -> Indexer:
+    ix = Indexer.__new__(Indexer)
+    ix.api_url = "https://api.example.test"
+    ix.corpus_key = "c"
+    ix.api_key = "k"
+    ix.x_source = "vectara-ingest-test"
+    ix.cfg = _cfg()
+    ix.session = MagicMock()
+    ix.verbose = False
+    ix.store_docs = False
+    ix.reindex = False
+    ix.incremental = False
+    ix.static_metadata = None
+    ix.add_image_bytes = True
+    ix.use_core_indexing = False
+    ix._init_processors = MagicMock()
+    posted = MagicMock()
+    posted.status_code = 201
+    ix.session.post.return_value = posted
+    return ix
+
+
+class TestAddImageBytesNormalization(unittest.TestCase):
+    def _index(self, texts, metadatas, image_bytes):
+        ix = _make_indexer()
+        ok = ix.index_segments(
+            doc_id="doc1",
+            texts=texts,
+            metadatas=metadatas,
+            doc_metadata={'url': 'https://example.test/p'},
+            doc_title="Page",
+            image_bytes=image_bytes,
+        )
+        self.assertTrue(ok)
+        return json.loads(ix.session.post.call_args.kwargs['data'])
+
+    def test_image_part_and_description_are_normalized(self):
+        image_id = "web_page_image_0"
+        body = self._index(
+            texts=[COMPOSED],
+            metadatas=[{'element_type': 'image', 'image_id': image_id}],
+            image_bytes=[(image_id, b"\x89PNG\r\n\x1a\n stub bytes")],
+        )
+        self.assertEqual(body['type'], 'core')
+        image_part = next(p for p in body['document_parts'] if p.get('image_id') == image_id)
+        self.assertEqual(image_part['text'], DECOMPOSED)
+        self.assertEqual(body['images'][0]['description'], DECOMPOSED)
+
+    def test_plain_text_part_is_normalized(self):
+        image_id = "web_page_image_0"
+        body = self._index(
+            texts=[COMPOSED, "a picture"],
+            metadatas=[
+                {'element_type': 'text'},
+                {'element_type': 'image', 'image_id': image_id},
+            ],
+            image_bytes=[(image_id, b"\x89PNG\r\n\x1a\n stub bytes")],
+        )
+        text_part = next(p for p in body['document_parts']
+                         if p.get('metadata', {}).get('element_type') == 'text')
+        self.assertEqual(text_part['text'], DECOMPOSED)
+
+    def test_metadata_values_are_normalized(self):
+        image_id = "web_page_image_0"
+        body = self._index(
+            texts=["a picture"],
+            metadatas=[{'element_type': 'image', 'image_id': image_id, 'alt_text': COMPOSED}],
+            image_bytes=[(image_id, b"\x89PNG\r\n\x1a\n stub bytes")],
+        )
+        image_part = next(p for p in body['document_parts'] if p.get('image_id') == image_id)
+        self.assertEqual(image_part['metadata']['alt_text'], DECOMPOSED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_split_oversized_retry.py
+++ b/tests/test_split_oversized_retry.py
@@ -1,0 +1,104 @@
+"""Regression tests: the split_oversized retry must fire only for oversized 400s.
+
+index_segments retries a failed upload with split_oversized=True. split_oversized
+only changes the document when a section/table exceeds MAX_SECTION_CHARS, so the
+retry is worthwhile *only* when such an oversized part exists. Any other 400
+(e.g. a schema error like an unrecognized field) has nothing to split and must
+fail loudly instead of being silently retried into a degraded document.
+"""
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.modules.setdefault('cairosvg', MagicMock())
+
+from omegaconf import OmegaConf
+
+from core.document_builder import MAX_SECTION_CHARS
+from core.indexer import Indexer, _document_has_oversized_part
+
+
+def _base_cfg(doc_processing: dict) -> OmegaConf:
+    return OmegaConf.create({
+        'vectara': {'verbose': False},
+        'crawling': {'crawler_type': 'test'},
+        'doc_processing': doc_processing,
+    })
+
+
+class TestHasOversizedPart(unittest.TestCase):
+    """The pure gate helper: True only when splitting would change the document."""
+
+    def test_short_sections_is_false(self):
+        doc = {'sections': [{'text': 'short'}, {'text': 'also short'}]}
+        self.assertFalse(_document_has_oversized_part(doc))
+
+    def test_oversized_section_text_is_true(self):
+        doc = {'sections': [{'text': 'a' * (MAX_SECTION_CHARS + 1)}]}
+        self.assertTrue(_document_has_oversized_part(doc))
+
+    def test_oversized_bundled_table_is_true(self):
+        big_rows = [[{'text_value': 'a' * 100}] for _ in range(400)]
+        doc = {'sections': [{'text': '', 'tables': [{'data': {'headers': [], 'rows': big_rows}}]}]}
+        self.assertTrue(_document_has_oversized_part(doc))
+
+    def test_image_bytes_shape_is_false(self):
+        # The add_image_bytes repro shape: short image-summary sections plus the
+        # core-only images/document_parts keys. Nothing is oversized -> no retry.
+        doc = {
+            'sections': [{'text': 'a picture of a cat'}],
+            'images': [{'id': 'img0', 'image_data': {'data': 'x' * 50000}}],
+            'document_parts': [{'text': 'a picture of a cat', 'image_id': 'img0'}],
+        }
+        self.assertFalse(_document_has_oversized_part(doc))
+
+
+class TestRetryGateInIndexSegments(unittest.TestCase):
+    """index_segments retries only when the rejected document has an oversized part."""
+
+    def _make_indexer(self):
+        ix = Indexer.__new__(Indexer)
+        ix.cfg = _base_cfg({})
+        ix.verbose = False
+        ix.add_image_bytes = False
+        ix.static_metadata = None
+        ix._init_processors = MagicMock()
+        ix._build_image_bytes_dict = MagicMock(return_value={})
+        ix.delete_doc = MagicMock(return_value=True)
+
+        # index_document always fails with a 400, like a rejected upload.
+        def _fail(*args, **kwargs):
+            ix._last_response_status = 400
+            return False
+        ix.index_document = MagicMock(side_effect=_fail)
+        return ix
+
+    def test_non_oversized_400_does_not_retry(self):
+        ix = self._make_indexer()
+        ok = ix.index_segments(
+            doc_id="doc1",
+            texts=["short body text"],
+            metadatas=[{'element_type': 'text'}],
+            doc_metadata={'url': 'https://example.test/p'},
+            doc_title="Page",
+        )
+        self.assertFalse(ok)
+        self.assertEqual(ix.index_document.call_count, 1)  # no retry
+        ix.delete_doc.assert_not_called()
+
+    def test_oversized_400_retries_with_split(self):
+        ix = self._make_indexer()
+        ok = ix.index_segments(
+            doc_id="doc2",
+            texts=["a" * (MAX_SECTION_CHARS + 5000)],
+            metadatas=[{'element_type': 'text'}],
+            doc_metadata={'url': 'https://example.test/p'},
+            doc_title="Page",
+        )
+        self.assertFalse(ok)
+        self.assertEqual(ix.index_document.call_count, 2)  # retried
+        ix.delete_doc.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_image_bytes.py
+++ b/tests/test_web_image_bytes.py
@@ -1,0 +1,58 @@
+"""Regression: web image binary must be stored as a renderable raster.
+
+SVG web images were stored as raw SVG bytes but labeled image/png (the MIME
+sniffer's default fallback), so the corpus UI could not render them. The binary
+for an SVG must be routed through cairosvg to a rasterized PNG; raster images
+pass through unchanged.
+
+cairosvg needs the native libcairo (present in the Docker image, absent in most
+local envs), so it is stubbed here — the real rasterization is covered by the
+end-to-end Docker run. These tests assert the branching logic: SVG goes through
+svg2png, raster is read as-is.
+"""
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+PNG_MAGIC = b'\x89PNG\r\n\x1a\n'
+# A minimal valid 1x1 PNG, used as the stubbed svg2png output and the raster input.
+_TINY_PNG = (
+    b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01'
+    b'\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc````'
+    b'\x00\x00\x00\x05\x00\x01\xa5\xf6E@\x00\x00\x00\x00IEND\xaeB`\x82'
+)
+
+# Stub cairosvg (no libcairo locally); svg2png returns known PNG bytes.
+_cairosvg_stub = MagicMock()
+_cairosvg_stub.svg2png.return_value = _TINY_PNG
+sys.modules['cairosvg'] = _cairosvg_stub
+
+from core.image_processor import ImageProcessor
+from core.indexer import Indexer
+
+
+class TestReadRenderableImageBytes(unittest.TestCase):
+    def test_svg_is_routed_through_rasterizer(self):
+        with tempfile.NamedTemporaryFile(suffix='.svg', delete=False, mode='w') as f:
+            f.write('<svg xmlns="http://www.w3.org/2000/svg"/>')
+            svg_path = f.name
+        data = ImageProcessor._read_renderable_image_bytes(svg_path, is_svg=True)
+        _cairosvg_stub.svg2png.assert_called_once_with(url=svg_path)
+        self.assertTrue(data.startswith(PNG_MAGIC),
+                        "SVG must be stored as rasterized PNG bytes")
+        # The MIME sniffer now agrees it is a PNG (previously defaulted to png over SVG bytes).
+        self.assertEqual(
+            Indexer._detect_image_mime_type(Indexer.__new__(Indexer), "web_x_image_0", data),
+            "image/png")
+
+    def test_raster_passes_through_unchanged(self):
+        with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as f:
+            f.write(_TINY_PNG)
+            png_path = f.name
+        data = ImageProcessor._read_renderable_image_bytes(png_path, is_svg=False)
+        self.assertEqual(data, _TINY_PNG)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When add_image_bytes was enabled, image-bearing documents were sent to the structured /documents endpoint carrying the core-only `images` and `document_parts` fields. The API rejected them with 400 "Unrecognized field images" (StructuredDocument), silently dropping the whole document — recurring once per image-bearing page in a crawl.

Root cause: index_segments injected `images`/`document_parts` but the wire type was decided independently from use_core_indexing, so a structured document ended up carrying core-only fields.

Three changes in core/indexer.py:

- index_segments: decide core BEFORE build_document whenever binary image data will be attached, so the document is built in proper core shape (document_parts, title in metadata, no top-level title/sections). This is the correctness invariant — a document carrying core-only fields is always typed core.
- __init__: when add_image_bytes is on with the docling parser and chunking is off, default docling_config.chunking_strategy to 'hierarchical' (structure-based, no tokenizer model needed) so core parts are well-sized instead of one oversized blob; this also auto-enables core indexing via _is_chunking_enabled().
- index_url: route image-bearing web pages through the local docling parser (index_file) instead of the always-structured inline path, and add a force_local_processing flag to index_file so the temp .html is parsed locally even though the source URI has no file extension (the should_process_locally heuristic keys off the URI and would otherwise send it to the raw upload path, dropping the image bytes).

Adds tests/test_add_image_bytes_core_routing.py covering all three: the core-shape invariant, the chunking-strategy default, and the web routing.


Claude-Session: https://claude.ai/code/session_01XCM6wESpvufYFZrAf7J1ZU