### PR TITLE
Support GPT-5 / o-series models in the OpenAI path

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -21,6 +21,23 @@ except ImportError:
 # Stores (project_id, location, credentials_file) tuple when initialized
 _vertex_ai_init_state = None
 
+# OpenAI model families requiring the newer Chat Completions parameters:
+# GPT-5 series and o-series reasoning models reject `max_tokens` (they need
+# `max_completion_tokens`) and reject a custom `temperature` (only default=1 allowed).
+_OPENAI_NEW_PARAM_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+
+
+def _openai_token_params(model_name: str, max_tokens: int) -> dict:
+    """Token/temperature kwargs for chat.completions.create, selected by model name.
+
+    - GPT-5 / o-series: {"max_completion_tokens": n}  (temperature omitted)
+    - all others:       {"max_tokens": n, "temperature": 0}
+    """
+    name = (model_name or "").lower()
+    if name.startswith(_OPENAI_NEW_PARAM_PREFIXES):
+        return {"max_completion_tokens": max_tokens}
+    return {"max_tokens": max_tokens, "temperature": 0}
+
 def get_api_key(provider: str, cfg: OmegaConf, model_type: str = None) -> str:
     """
     Get the API key for the specified provider.
@@ -125,14 +142,14 @@ def generate(
             client = OpenAI(api_key=model_api_key, base_url=model_config.get('base_url', None))
         else:
             client = OpenAI(api_key=model_api_key)
+        model_name = model_config.get('model_name', 'gpt-4o')
         response = client.chat.completions.create(
-            model=model_config.get('model_name', 'gpt-4o'),
+            model=model_name,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}
             ],
-            temperature=0,
-            max_tokens=max_tokens,
+            **_openai_token_params(model_name, max_tokens),
         )
         res = str(response.choices[0].message.content)
     elif provider == 'anthropic':
@@ -214,11 +231,11 @@ def generate_image_summary(
             }
         ]
 
+        model_name = model_config.get('model_name', 'gpt-4o')
         response = client.chat.completions.create(
-            model=model_config.get('model_name', 'gpt-4o'),
+            model=model_name,
             messages=messages,
-            max_tokens=max_tokens,
-            temperature=0,
+            **_openai_token_params(model_name, max_tokens),
         )
         summary = response.choices[0].message.content
         return summary

--- a/tests/test_openai_token_params.py
+++ b/tests/test_openai_token_params.py
@@ -1,0 +1,34 @@
+"""Regression tests for OpenAI token/temperature parameter selection.
+
+GPT-5 series and o-series reasoning models reject `max_tokens` (they require
+`max_completion_tokens`) and reject a non-default `temperature`. Older models
+(gpt-4o, gpt-4.1) require the classic `max_tokens` + `temperature=0`. The helper
+`_openai_token_params` in core/models.py picks the right kwargs by model name.
+"""
+import unittest
+
+from core.models import _openai_token_params
+
+
+class TestOpenAITokenParams(unittest.TestCase):
+    def test_new_models_use_max_completion_tokens_and_omit_temperature(self):
+        for name in [
+            "gpt-5.4-mini", "gpt-5", "GPT-5.4-Mini",
+            "o1", "o1-mini", "o3", "o3-mini", "o4-mini",
+        ]:
+            with self.subTest(model=name):
+                params = _openai_token_params(name, 1234)
+                self.assertEqual(params, {"max_completion_tokens": 1234})
+                self.assertNotIn("temperature", params)
+                self.assertNotIn("max_tokens", params)
+
+    def test_legacy_models_use_max_tokens_and_temperature_zero(self):
+        for name in ["gpt-4o", "gpt-4o-mini", "gpt-4.1-mini", "gpt-4-turbo"]:
+            with self.subTest(model=name):
+                params = _openai_token_params(name, 2048)
+                self.assertEqual(params, {"max_tokens": 2048, "temperature": 0})
+                self.assertNotIn("max_completion_tokens", params)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Configuring an OpenAI GPT-5 or o-series model (e.g. \`gpt-5.4-mini\`) for text generation or image summarization fails with:

\`\`\`
400 - Unsupported parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead.
\`\`\`

\`core/models.py\` hardcoded \`max_tokens\` and \`temperature=0\` on the openai/private branch of both \`generate()\` and \`generate_image_summary()\`. GPT-5 series (\`gpt-5*\`) and o-series reasoning models (\`o1*\`/\`o3*\`/\`o4*\`) renamed \`max_tokens\` → \`max_completion_tokens\` and only accept the default temperature.

## Fix

A small \`_openai_token_params(model_name, max_tokens)\` helper returns the correct kwargs by model name and is used at both \`chat.completions.create\` call sites:

- GPT-5 / o-series → \`{"max_completion_tokens": n}\` (temperature omitted)
- everything else → \`{"max_tokens": n, "temperature": 0}\` (byte-identical to before)

The \`anthropic\` and \`vertex\` branches are untouched, and no caller signatures change.

## Tests

New \`tests/test_openai_token_params.py\` verifies the helper picks \`max_completion_tokens\` (no temperature) for gpt-5.4-mini/gpt-5/o1/o3/o4 variants and \`max_tokens\`+\`temperature=0\` for gpt-4o/gpt-4.1 — no network calls.

\`\`\`
python -m pytest tests/test_openai_token_params.py tests/test_contextual.py -q
6 passed
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)