### PR TITLE
fix: repair arxiv, yt, and pmc crawlers broken by upstream changes

### DIFF
--- a/crawlers/arxiv_crawler.py
+++ b/crawlers/arxiv_crawler.py
@@ -99,8 +99,9 @@ class ArxivCrawler(Crawler):
 
         # filter by publication year
         papers = []
+        client = arxiv.Client()
         try:
-            for result in search.results():
+            for result in client.results(search):
                 date = result.published.date()
                 if date.year < year:
                     continue

--- a/crawlers/arxiv_crawler.py
+++ b/crawlers/arxiv_crawler.py
@@ -116,6 +116,9 @@ class ArxivCrawler(Crawler):
                     'published': str(date)
                 })
         except Exception as e:
+            if not papers:
+                logger.error(f"arxiv query failed before returning any results: {e}", exc_info=True)
+                raise
             logger.warning(f"Exception {e}, we have {len(papers)} papers already, so will continue with indexing")
 
         if len(papers) == 0:

--- a/crawlers/pmc_crawler.py
+++ b/crawlers/pmc_crawler.py
@@ -110,9 +110,11 @@ class PmcCrawler(Crawler):
 
             self.crawled_pmc_ids.add(pmc_id)
             logger.info(f"Indexing paper {pmc_id} with publication date {pub_date} and title '{title}'")
-            pdf_url = f"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC{pmc_id}/pdf/"
+            pdf_url = f"https://pmc.ncbi.nlm.nih.gov/articles/PMC{pmc_id}/pdf/"
 
-            self.indexer.index_url(pdf_url, metadata={'url': pdf_url, 'source': 'pmc', 'title': title, "publicationDate": pub_date})
+            succeeded = self.indexer.index_url(pdf_url, metadata={'url': pdf_url, 'source': 'pmc', 'title': title, "publicationDate": pub_date})
+            if not succeeded:
+                logger.warning(f"Failed to index paper {pmc_id} ({pdf_url})")
 
     def _get_xml_dict(self) -> Any:
         days_back = 1

--- a/crawlers/yt_crawler.py
+++ b/crawlers/yt_crawler.py
@@ -3,7 +3,7 @@ logger = logging.getLogger(__name__)
 from core.crawler import Crawler
 import os
 
-from pytube import Playlist, YouTube
+from pytubefix import Playlist, YouTube
 from pydub import AudioSegment
 
 from youtube_transcript_api import YouTubeTranscriptApi

--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ pytesseract==0.3.13
 xmltodict==0.13.0
 nbconvert==7.17.0
 nbformat==5.10.4
-arxiv==1.4.7
+arxiv==4.0.0
 goose3==3.1.19
 sqlalchemy==2.0.14
 pymysql==1.1.1
@@ -61,7 +61,7 @@ datasets==3.6.0
 torch>=2.7.1
 torchvision>=0.22.0
 pydub==0.25.1
-pytube==15.0.0
+pytubefix==10.10.1
 youtube-transcript-api==0.6.2
 sec-downloader==0.12.2
 openpyxl==3.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ aiohttp==3.13.3
     #   fsspec
     #   llama-index-core
     #   mwapi
+    #   pytubefix
 aiosignal==1.4.0
     # via aiohttp
 aiosqlite==0.21.0
@@ -32,7 +33,7 @@ anyio==4.9.0
     #   google-genai
     #   httpx
     #   openai
-arxiv==1.4.7
+arxiv==4.0.0
     # via -r requirements.in
 asn1crypto==1.5.1
     # via scramp
@@ -214,9 +215,7 @@ fastdatamask==0.0.6
 fastjsonschema==2.21.1
     # via nbformat
 feedparser==6.0.11
-    # via
-    #   -r requirements.in
-    #   arxiv
+    # via -r requirements.in
 filelock==3.18.0
     # via
     #   datasets
@@ -465,6 +464,7 @@ llvmlite==0.47.0
 lxml==6.1.0
     # via
     #   -r requirements.in
+    #   arxiv
     #   docling-slim
     #   goose3
     #   justext
@@ -566,6 +566,8 @@ nltk==3.9.4
     #   -r requirements.in
     #   llama-index-core
     #   unstructured
+nodejs-wheel-binaries==24.16.0
+    # via pytubefix
 notion-client==2.2.1
     # via -r requirements.in
 numba==0.65.1
@@ -987,7 +989,7 @@ python-pptx==1.0.2
     #   docling-slim
 python-slugify==8.0.1
     # via -r requirements.in
-pytube==15.0.0
+pytubefix==10.10.1
     # via -r requirements.in
 pytz==2025.2
     # via
@@ -1036,6 +1038,7 @@ regex==2024.11.6
 requests==2.32.3
     # via
     #   -r requirements.in
+    #   arxiv
     #   boxsdk
     #   datasets
     #   docling-slim

--- a/tests/test_arxiv_crawler.py
+++ b/tests/test_arxiv_crawler.py
@@ -56,6 +56,64 @@ class TestArxivClientApi(unittest.TestCase):
         indexed_url = crawler.indexer.index_url.call_args.args[0]
         self.assertEqual(indexed_url, "https://arxiv.org/pdf/2401.00001v1.pdf")
 
+    def _make_crawler(self):
+        crawler = ArxivCrawler.__new__(ArxivCrawler)
+        crawler.cfg = OmegaConf.create({
+            "arxiv_crawler": {
+                "n_papers": 1,
+                "query_terms": ["llm"],
+                "start_year": 2020,
+                "arxiv_category": "cs",
+                "sort_by": "date",
+            },
+        })
+        crawler.indexer = MagicMock()
+        return crawler
+
+    def test_crawl_raises_when_query_fails_before_any_results(self):
+        # Regression: an upstream failure before any results were fetched must
+        # not be swallowed — otherwise ingest marks the crawl completed even
+        # though it never reached arXiv.
+        mock_arxiv = MagicMock()
+        mock_arxiv.Client.return_value.results.side_effect = RuntimeError("arxiv down")
+
+        crawler = self._make_crawler()
+        with patch("crawlers.arxiv_crawler.arxiv", mock_arxiv), \
+             patch("crawlers.arxiv_crawler.create_session_with_retries",
+                   return_value=MagicMock()), \
+             patch("crawlers.arxiv_crawler.configure_session_for_ssl"):
+            with self.assertRaises(RuntimeError):
+                crawler.crawl()
+
+        crawler.indexer.index_url.assert_not_called()
+
+    def test_crawl_continues_with_partial_results_on_midstream_failure(self):
+        # A failure after some results were fetched should still index what
+        # we have (existing behavior).
+        result = MagicMock()
+        result.entry_id = "http://arxiv.org/abs/2401.00001v1"
+        result.published.date.return_value = date(2024, 1, 1)
+        result.pdf_url = "https://arxiv.org/pdf/2401.00001v1"
+        result.title = "A paper"
+        result.authors = ["A. Author"]
+        result.summary = "An abstract"
+
+        def one_then_fail(search):
+            yield result
+            raise RuntimeError("connection dropped")
+
+        mock_arxiv = MagicMock()
+        mock_arxiv.Client.return_value.results.side_effect = one_then_fail
+
+        crawler = self._make_crawler()
+        with patch("crawlers.arxiv_crawler.arxiv", mock_arxiv), \
+             patch("crawlers.arxiv_crawler.create_session_with_retries",
+                   return_value=MagicMock()), \
+             patch("crawlers.arxiv_crawler.configure_session_for_ssl"):
+            crawler.crawl()
+
+        crawler.indexer.index_url.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_arxiv_crawler.py
+++ b/tests/test_arxiv_crawler.py
@@ -1,0 +1,61 @@
+import sys
+import importlib.machinery
+import unittest
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+# Stub heavy/optional deps pulled in via core.crawler/core.indexer.
+for mod in ["arxiv", "cairosvg", "whisper", "pdf2image", "pydub"]:
+    sys.modules.setdefault(mod, MagicMock())
+_playwright_mock = MagicMock()
+_playwright_mock.__spec__ = importlib.machinery.ModuleSpec("playwright", None)
+sys.modules.setdefault("playwright", _playwright_mock)
+sys.modules.setdefault("playwright.sync_api", MagicMock())
+
+from omegaconf import OmegaConf
+
+from crawlers.arxiv_crawler import ArxivCrawler
+
+
+class TestArxivClientApi(unittest.TestCase):
+
+    def test_crawl_uses_client_results(self):
+        # Regression: arxiv 2.x+ removed Search.results(); papers must be
+        # fetched via arxiv.Client().results(search) or the crawler silently
+        # indexes nothing.
+        result = MagicMock()
+        result.entry_id = "http://arxiv.org/abs/2401.00001v1"
+        result.published.date.return_value = date(2024, 1, 1)
+        result.pdf_url = "https://arxiv.org/pdf/2401.00001v1"
+        result.title = "A paper"
+        result.authors = ["A. Author"]
+        result.summary = "An abstract"
+
+        mock_arxiv = MagicMock()
+        mock_arxiv.Client.return_value.results.return_value = iter([result])
+
+        crawler = ArxivCrawler.__new__(ArxivCrawler)
+        crawler.cfg = OmegaConf.create({
+            "arxiv_crawler": {
+                "n_papers": 1,
+                "query_terms": ["llm"],
+                "start_year": 2020,
+                "arxiv_category": "cs",
+                "sort_by": "date",
+            },
+        })
+        crawler.indexer = MagicMock()
+
+        with patch("crawlers.arxiv_crawler.arxiv", mock_arxiv), \
+             patch("crawlers.arxiv_crawler.create_session_with_retries",
+                   return_value=MagicMock()), \
+             patch("crawlers.arxiv_crawler.configure_session_for_ssl"):
+            crawler.crawl()
+
+        crawler.indexer.index_url.assert_called_once()
+        indexed_url = crawler.indexer.index_url.call_args.args[0]
+        self.assertEqual(indexed_url, "https://arxiv.org/pdf/2401.00001v1.pdf")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pmc_crawler.py
+++ b/tests/test_pmc_crawler.py
@@ -1,0 +1,66 @@
+import sys
+import importlib.machinery
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Stub heavy/optional deps pulled in via core.crawler/core.indexer.
+for mod in ["Bio", "cairosvg", "whisper", "pdf2image", "pydub"]:
+    sys.modules.setdefault(mod, MagicMock())
+_playwright_mock = MagicMock()
+_playwright_mock.__spec__ = importlib.machinery.ModuleSpec("playwright", None)
+sys.modules.setdefault("playwright", _playwright_mock)
+sys.modules.setdefault("playwright.sync_api", MagicMock())
+
+from omegaconf import OmegaConf
+
+from crawlers.pmc_crawler import PmcCrawler
+
+ARTICLE_XML = """<pmc-articleset><article>
+<article-title>A paper</article-title>
+<pub-date><year>2024</year><month>1</month><day>1</day></pub-date>
+</article></pmc-articleset>"""
+
+
+def make_crawler():
+    crawler = PmcCrawler.__new__(PmcCrawler)
+    crawler.cfg = OmegaConf.create({"pmc_crawler": {}})
+    crawler.indexer = MagicMock()
+    crawler.rate_limiter = MagicMock()
+    crawler.crawled_pmc_ids = set()
+    crawler.session = MagicMock()
+    response = MagicMock()
+    response.status_code = 200
+    response.text = ARTICLE_XML
+    crawler.session.get.return_value = response
+    return crawler
+
+
+class TestPmcPaperIndexing(unittest.TestCase):
+
+    def test_pdf_url_uses_current_pmc_domain(self):
+        # Regression: www.ncbi.nlm.nih.gov/pmc/... now 301s to
+        # pmc.ncbi.nlm.nih.gov; the crawler must use the current domain.
+        crawler = make_crawler()
+        with patch("crawlers.pmc_crawler.get_top_n_papers",
+                   return_value=["123"]):
+            crawler.index_papers_by_topic("topic", 1)
+
+        crawler.indexer.index_url.assert_called_once()
+        indexed_url = crawler.indexer.index_url.call_args.args[0]
+        self.assertEqual(
+            indexed_url, "https://pmc.ncbi.nlm.nih.gov/articles/PMC123/pdf/")
+
+    def test_index_url_failure_is_logged(self):
+        # Regression: index_url's return value was discarded, so per-paper
+        # indexing failures were completely silent.
+        crawler = make_crawler()
+        crawler.indexer.index_url.return_value = False
+        with patch("crawlers.pmc_crawler.get_top_n_papers",
+                   return_value=["123"]):
+            with self.assertLogs("crawlers.pmc_crawler", level="WARNING") as cm:
+                crawler.index_papers_by_topic("topic", 1)
+        self.assertTrue(any("123" in line for line in cm.output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_yt_crawler.py
+++ b/tests/test_yt_crawler.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 # yt_crawler imports several heavy/optional media deps; stub them all.
-for mod in ["cairosvg", "whisper", "pdf2image", "pytube", "pydub",
+for mod in ["cairosvg", "whisper", "pdf2image", "pytubefix", "pydub",
             "youtube_transcript_api"]:
     sys.modules.setdefault(mod, MagicMock())
 


### PR DESCRIPTION
Regression testing surfaced three crawlers broken by upstream changes. All three were reproduced against the live services before fixing.

## arxiv
`arxiv==1.4.7` queries `http://export.arxiv.org/api/query`; arXiv now 301s HTTP requests, the library raises `HTTPError`, and the crawler swallowed it — logging "Found 0 papers" and exiting 0. Upgraded to `arxiv==4.0.0` and switched the crawl loop to `arxiv.Client().results(search)`, since `Search.results()` was removed in 2.x+. Verified live: results return with all attributes the crawler reads, and the `pdf_url + ".pdf"` form still resolves.

## yt
pytube 15.0.0 silently returns 0 videos for playlists against current YouTube, and the project is unmaintained. Replaced with `pytubefix==10.10.1` (MIT) — drop-in for everything the crawler uses (verified live: 49/49 videos parsed on a playlist where pytube returned 0). Only the import line changed. Note: pytubefix depends on `nodejs-wheel-binaries` (used to generate YouTube bot-check tokens), which adds ~50MB to installs.

## pmc
Two issues: paper PDF URLs were built on the retired `www.ncbi.nlm.nih.gov/pmc/` domain (now a 301 to `pmc.ncbi.nlm.nih.gov`), and `index_url`'s return value was discarded, so per-paper failures were invisible. Now uses the current domain and logs a warning naming the paper ID and URL on failure.

Caveat: NCBI returns 403 to python-requests on both old and new domains (TLS fingerprinting), so PDF fetching relies on the playwright path passing their bot check. If papers still fail, the follow-up is to index the efetch JATS XML the crawler already downloads instead of scraping PDFs — the warning log added here makes that visible.

## Tests
New regression tests for the arxiv client API usage (`tests/test_arxiv_crawler.py`) and the pmc domain + failure logging (`tests/test_pmc_crawler.py`); `tests/test_yt_crawler.py` stub list updated for the import swap. Full suite: 627 passed; the 5 `test_file_processor.py` failures are pre-existing on `main` (verified on a clean checkout).

`requirements.txt` regenerated with the repo's `uv pip compile` command — diff is limited to the two packages and their direct dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSM46p9RgruuJE4hQCTDjz