### PR TITLE
Upgrade dependencies for Dependabot alerts; fix PMC crawler URL

### DIFF
--- a/crawlers/pmc_crawler.py
+++ b/crawlers/pmc_crawler.py
@@ -110,11 +110,13 @@ class PmcCrawler(Crawler):
 
             self.crawled_pmc_ids.add(pmc_id)
             logger.info(f"Indexing paper {pmc_id} with publication date {pub_date} and title '{title}'")
-            pdf_url = f"https://pmc.ncbi.nlm.nih.gov/articles/PMC{pmc_id}/pdf/"
+            # PMC serves a JS interstitial at /pdf/ that yields no content for
+            # non-browser clients, so index the article HTML page instead.
+            article_url = f"https://pmc.ncbi.nlm.nih.gov/articles/PMC{pmc_id}/"
 
-            succeeded = self.indexer.index_url(pdf_url, metadata={'url': pdf_url, 'source': 'pmc', 'title': title, "publicationDate": pub_date})
+            succeeded = self.indexer.index_url(article_url, metadata={'url': article_url, 'source': 'pmc', 'title': title, "publicationDate": pub_date})
             if not succeeded:
-                logger.warning(f"Failed to index paper {pmc_id} ({pdf_url})")
+                logger.warning(f"Failed to index paper {pmc_id} ({article_url})")
 
     def _get_xml_dict(self) -> Any:
         days_back = 1

--- a/requirements-extra.in
+++ b/requirements-extra.in
@@ -1,7 +1,7 @@
 -c requirements.txt
 
 unstructured[all-docs]==0.18.26
-nltk>=3.9.4
+nltk>=3.10.0
 presidio-analyzer==2.2.362
 presidio-anonymizer==2.2.362
 pikepdf==9.8.1

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -126,6 +126,7 @@ filelock==3.18.0
     #   huggingface-hub
     #   tldextract
     #   torch
+    #   transformers
 filetype==1.2.0
     # via
     #   -c requirements.txt
@@ -176,7 +177,7 @@ h11==0.16.0
     #   httpcore
 h5py==3.12.1
     # via -r requirements-extra.in
-hf-xet==1.5.2 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.5.2 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via
     #   -c requirements.txt
     #   huggingface-hub
@@ -191,10 +192,9 @@ httpcore==1.0.9
 httpx==0.28.1
     # via
     #   -c requirements.txt
-    #   huggingface-hub
     #   unstructured-client
     #   weasel
-huggingface-hub==1.13.0
+huggingface-hub==0.36.2
     # via
     #   -c requirements.txt
     #   accelerate
@@ -590,10 +590,12 @@ requests==2.34.2
     # via
     #   -c requirements.txt
     #   google-api-core
+    #   huggingface-hub
     #   requests-file
     #   requests-toolbelt
     #   spacy
     #   tldextract
+    #   transformers
     #   unstructured
 requests-file==2.1.0
     # via
@@ -703,7 +705,7 @@ tqdm==4.67.1
     #   spacy
     #   transformers
     #   unstructured
-transformers==5.8.1
+transformers==4.57.6
     # via
     #   -c requirements.txt
     #   unstructured-inference
@@ -714,9 +716,7 @@ triton==3.3.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
 typer==0.15.4
     # via
     #   -c requirements.txt
-    #   huggingface-hub
     #   spacy
-    #   transformers
     #   weasel
 typing-extensions==4.16.0
     # via

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -79,7 +79,7 @@ contourpy==1.3.2
     #   -c requirements.txt
     #   -r requirements-extra.in
     #   matplotlib
-cryptography==46.0.7
+cryptography==48.0.1
     # via
     #   -c requirements.txt
     #   google-auth
@@ -100,6 +100,10 @@ dataclasses-json==0.6.7
     # via
     #   -c requirements.txt
     #   unstructured
+defusedxml==0.7.1
+    # via
+    #   -c requirements.txt
+    #   nltk
 deprecated==1.2.18
     # via
     #   -c requirements.txt
@@ -122,7 +126,6 @@ filelock==3.18.0
     #   huggingface-hub
     #   tldextract
     #   torch
-    #   transformers
 filetype==1.2.0
     # via
     #   -c requirements.txt
@@ -173,7 +176,7 @@ h11==0.16.0
     #   httpcore
 h5py==3.12.1
     # via -r requirements-extra.in
-hf-xet==1.1.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.5.2 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via
     #   -c requirements.txt
     #   huggingface-hub
@@ -188,9 +191,10 @@ httpcore==1.0.9
 httpx==0.28.1
     # via
     #   -c requirements.txt
+    #   huggingface-hub
     #   unstructured-client
     #   weasel
-huggingface-hub==0.34.4
+huggingface-hub==1.13.0
     # via
     #   -c requirements.txt
     #   accelerate
@@ -285,7 +289,7 @@ networkx==3.5
     #   -c requirements.txt
     #   torch
     #   unstructured
-nltk==3.9.4
+nltk==3.10.0
     # via
     #   -c requirements.txt
     #   -r requirements-extra.in
@@ -382,7 +386,7 @@ omegaconf==2.3.0
     # via
     #   -c requirements.txt
     #   effdet
-onnx==1.21.0
+onnx==1.22.0
     # via
     #   -c requirements.txt
     #   unstructured
@@ -430,7 +434,7 @@ pdfminer-six==20260107
     #   unstructured-inference
 phonenumbers==8.13.55
     # via presidio-analyzer
-pi-heif==0.22.0
+pi-heif==1.4.0
     # via
     #   -c requirements.txt
     #   unstructured
@@ -439,7 +443,7 @@ pikepdf==9.8.1
     #   -c requirements.txt
     #   -r requirements-extra.in
     #   unstructured
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   -c requirements.txt
     #   matplotlib
@@ -516,7 +520,7 @@ pyparsing==3.2.3
     # via
     #   -c requirements.txt
     #   matplotlib
-pypdf==5.6.0
+pypdf==6.14.2
     # via
     #   -c requirements.txt
     #   unstructured
@@ -546,7 +550,7 @@ python-magic==0.4.27
     # via
     #   -c requirements.txt
     #   unstructured
-python-multipart==0.0.27
+python-multipart==0.0.32
     # via
     #   -c requirements.txt
     #   unstructured-inference
@@ -576,22 +580,20 @@ rapidfuzz==3.13.0
     #   -c requirements.txt
     #   unstructured
     #   unstructured-inference
-regex==2024.11.6
+regex==2026.7.19
     # via
     #   -c requirements.txt
     #   nltk
     #   presidio-analyzer
     #   transformers
-requests==2.32.3
+requests==2.34.2
     # via
     #   -c requirements.txt
     #   google-api-core
-    #   huggingface-hub
     #   requests-file
     #   requests-toolbelt
     #   spacy
     #   tldextract
-    #   transformers
     #   unstructured
 requests-file==2.1.0
     # via
@@ -642,7 +644,7 @@ sniffio==1.3.1
     # via
     #   -c requirements.txt
     #   anyio
-soupsieve==2.7
+soupsieve==2.9
     # via
     #   -c requirements.txt
     #   beautifulsoup4
@@ -675,7 +677,7 @@ tldextract==5.3.0
     # via
     #   -c requirements.txt
     #   presidio-analyzer
-tokenizers==0.21.1
+tokenizers==0.22.2
     # via
     #   -c requirements.txt
     #   transformers
@@ -701,7 +703,7 @@ tqdm==4.67.1
     #   spacy
     #   transformers
     #   unstructured
-transformers==4.55.0
+transformers==5.8.1
     # via
     #   -c requirements.txt
     #   unstructured-inference
@@ -712,9 +714,11 @@ triton==3.3.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
 typer==0.15.4
     # via
     #   -c requirements.txt
+    #   huggingface-hub
     #   spacy
+    #   transformers
     #   weasel
-typing-extensions==4.14.0
+typing-extensions==4.16.0
     # via
     #   -c requirements.txt
     #   anyio

--- a/requirements.in
+++ b/requirements.in
@@ -51,10 +51,14 @@ lxml[html_clean]==6.1.0
 html5lib==1.1
 unstructured[pdf]==0.18.26
 unstructured-inference>=1.0.5
-# >=5.5 required for CVE-2026-4372 / CVE-2026-5241 (RCE via malicious model
-# config.json; 4.x is unpatched). Earlier constraint history: >=4.56 fixed
-# docling's dtype= kwarg forwarding (Idefics3 TypeError).
-transformers[torch]>=5.5.0,<6
+# Capped at <5: transformers 5.x strict config validation rejects the
+# microsoft/table-transformer checkpoints gmft loads ("dilation": null fails
+# bool validation in from_pretrained), which breaks enable_gmft table
+# extraction entirely. NOTE: this reopens CVE-2026-4372 / CVE-2026-5241
+# (high, RCE via malicious model config.json; only patched in 5.3/5.5) —
+# re-raise the floor once gmft works with transformers 5.x.
+# >=4.56 required: fixes docling's dtype= kwarg forwarding (Idefics3 TypeError).
+transformers[torch]>=4.56.0,<5
 safetensors[torch]>=0.6.2
 datasets==3.6.0
 torch>=2.7.1
@@ -76,7 +80,7 @@ easyocr>=1.7.0
 llama-parse==0.6.68
 llama-cloud-services==0.6.68
 llama-index-core==0.14.2
-gmft==0.4.2
+gmft==0.4.3
 pypdf>=6.13.3
 furl==2.1.3
 office365-rest-python-client==2.6.2

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-requests==2.32.3
+requests>=2.32.4
 requests-ntlm==1.3.0
 certifi>=2024.8.30
 click==8.1.8
@@ -51,11 +51,10 @@ lxml[html_clean]==6.1.0
 html5lib==1.1
 unstructured[pdf]==0.18.26
 unstructured-inference>=1.0.5
-# >=4.56 required: earlier versions forward docling's dtype= kwarg straight into
-# the model constructor instead of consuming it, breaking CodeFormula/VLM loading
-# (Idefics3ForConditionalGeneration TypeError). Capped at <5 to avoid the 5.x jump
-# (huggingface-hub major bump) since 4.56 already fixes it.
-transformers[torch]>=4.56.0,<5
+# >=5.5 required for CVE-2026-4372 / CVE-2026-5241 (RCE via malicious model
+# config.json; 4.x is unpatched). Earlier constraint history: >=4.56 fixed
+# docling's dtype= kwarg forwarding (Idefics3 TypeError).
+transformers[torch]>=5.5.0,<6
 safetensors[torch]>=0.6.2
 datasets==3.6.0
 torch>=2.7.1
@@ -71,14 +70,14 @@ matplotlib==3.8.4
 cryptography==48.0.1
 python-pptx==1.0.2
 python-docx==1.1.2
-Pillow==12.2.0
+Pillow>=12.3.0
 docling==2.94.0
 easyocr>=1.7.0
 llama-parse==0.6.68
 llama-cloud-services==0.6.68
 llama-index-core==0.14.2
 gmft==0.4.2
-pypdf >= 3.0.0
+pypdf>=6.13.3
 furl==2.1.3
 office365-rest-python-client==2.6.2
 cairosvg==2.9.0
@@ -86,16 +85,16 @@ scrapy==2.16.0
 typer==0.15.4
 boxsdk[jwt]==3.10.0
 google-cloud-aiplatform==1.133.0
-nltk>=3.9.4
-aiohttp>=3.13.3
+nltk>=3.10.0
+aiohttp>=3.14.1
 pdfminer.six>=20251230
 protobuf>=5.29.6
 urllib3>=2.7.0
 python-multipart>=0.0.30
 pyasn1>=0.6.3
-pyjwt>=2.12.0
+pyjwt>=2.13.0
 pyopenssl>=26.0.0
-onnx>=1.21.0
+onnx>=1.22.0
 tornado>=6.5.6
 jaraco-context>=6.1.0
 wheel>=0.46.2
@@ -106,3 +105,9 @@ banks>=2.4.2
 docling-core>=2.74.1
 twisted>=26.4.0
 msgpack>=1.2.1
+# More transitive CVE floors: mistune/bleach via nbconvert; soupsieve via
+# beautifulsoup4; pi-heif via unstructured.
+mistune>=3.3.0
+bleach>=6.4.0
+soupsieve>=2.8.4
+pi-heif>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ aiofiles==24.1.0
     # via unstructured-client
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.2
     # via
     #   -r requirements.in
     #   fsspec
@@ -70,8 +70,10 @@ beautifulsoup4==4.12.3
     #   unstructured
 biopython==1.84
     # via -r requirements.in
-bleach==6.2.0
-    # via nbconvert
+bleach==6.4.0
+    # via
+    #   -r requirements.in
+    #   nbconvert
 boto3==1.42.63
     # via -r requirements.in
 botocore==1.42.63
@@ -160,6 +162,7 @@ defusedxml==0.7.1
     #   docling-core
     #   docling-slim
     #   nbconvert
+    #   nltk
     #   scrapy
 deprecated==1.2.18
     # via
@@ -224,7 +227,6 @@ filelock==3.18.0
     #   ray
     #   tldextract
     #   torch
-    #   transformers
 filetype==1.2.0
     # via
     #   banks
@@ -329,7 +331,7 @@ grpcio-status==1.62.3
     # via google-api-core
 h11==0.16.0
     # via httpcore
-hf-xet==1.1.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.5.2 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
 html5lib==1.1
     # via
@@ -348,13 +350,14 @@ httpx==0.28.1
     #   anthropic
     #   docling-slim
     #   google-genai
+    #   huggingface-hub
     #   llama-cloud
     #   llama-index-core
     #   notion-client
     #   openai
     #   synapseclient
     #   unstructured-client
-huggingface-hub==0.34.4
+huggingface-hub==1.13.0
     # via
     #   accelerate
     #   datasets
@@ -496,8 +499,10 @@ matplotlib==3.8.4
     #   unstructured-inference
 mdurl==0.1.2
     # via markdown-it-py
-mistune==2.0.5
-    # via nbconvert
+mistune==3.3.3
+    # via
+    #   -r requirements.in
+    #   nbconvert
 ml-dtypes==0.5.4
     # via onnx
 more-itertools==10.7.0
@@ -561,7 +566,7 @@ networkx==3.5
     #   torch
 ninja==1.13.0
     # via easyocr
-nltk==3.9.4
+nltk==3.10.0
     # via
     #   -r requirements.in
     #   llama-index-core
@@ -652,7 +657,7 @@ omegaconf==2.3.0
     #   -r requirements.in
     #   effdet
     #   rapidocr
-onnx==1.21.0
+onnx==1.22.0
     # via
     #   -r requirements.in
     #   unstructured
@@ -777,11 +782,13 @@ pdfminer-six==20260107
     #   unstructured-inference
 pg8000==1.31.5
     # via -r requirements.in
-pi-heif==0.22.0
-    # via unstructured
+pi-heif==1.4.0
+    # via
+    #   -r requirements.in
+    #   unstructured
 pikepdf==9.8.1
     # via unstructured
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   -r requirements.in
     #   cairosvg
@@ -906,7 +913,7 @@ pygments==2.19.1
     #   mpire
     #   nbconvert
     #   rich
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via
     #   -r requirements.in
     #   boxsdk
@@ -923,7 +930,7 @@ pyparsing==3.2.3
     # via
     #   httplib2
     #   matplotlib
-pypdf==5.6.0
+pypdf==6.14.2
     # via
     #   -r requirements.in
     #   unstructured
@@ -1028,12 +1035,12 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.11.6
+regex==2026.7.19
     # via
     #   nltk
     #   tiktoken
     #   transformers
-requests==2.32.3
+requests==2.34.2
     # via
     #   -r requirements.in
     #   boxsdk
@@ -1045,7 +1052,6 @@ requests==2.32.3
     #   google-cloud-storage
     #   google-genai
     #   goose3
-    #   huggingface-hub
     #   llama-index-core
     #   msal
     #   mwapi
@@ -1062,7 +1068,6 @@ requests==2.32.3
     #   synapseclient
     #   tiktoken
     #   tldextract
-    #   transformers
     #   tweepy
     #   unstructured
     #   youtube-transcript-api
@@ -1153,8 +1158,10 @@ sniffio==1.3.1
     #   anyio
     #   google-genai
     #   openai
-soupsieve==2.7
-    # via beautifulsoup4
+soupsieve==2.9
+    # via
+    #   -r requirements.in
+    #   beautifulsoup4
 sqlalchemy==2.0.14
     # via
     #   -r requirements.in
@@ -1251,7 +1258,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-transformers==4.57.6
+transformers==5.8.1
     # via
     #   -r requirements.in
     #   docling-core
@@ -1283,8 +1290,11 @@ typer==0.15.4
     #   -r requirements.in
     #   docling-core
     #   docling-slim
-typing-extensions==4.14.0
+    #   huggingface-hub
+    #   transformers
+typing-extensions==4.16.0
     # via
+    #   aiohttp
     #   aiosignal
     #   aiosqlite
     #   anthropic

--- a/requirements.txt
+++ b/requirements.txt
@@ -1042,7 +1042,7 @@ regex==2026.7.19
     #   nltk
     #   tiktoken
     #   transformers
-requests==2.34.2
+requests==2.33.1
     # via
     #   -r requirements.in
     #   arxiv

--- a/requirements.txt
+++ b/requirements.txt
@@ -227,6 +227,7 @@ filelock==3.18.0
     #   ray
     #   tldextract
     #   torch
+    #   transformers
 filetype==1.2.0
     # via
     #   banks
@@ -249,7 +250,7 @@ fsspec==2024.5.0
     #   torch
 furl==2.1.3
     # via -r requirements.in
-gmft==0.4.2
+gmft==0.4.3
     # via -r requirements.in
 google-api-core==2.25.0
     # via
@@ -331,7 +332,7 @@ grpcio-status==1.62.3
     # via google-api-core
 h11==0.16.0
     # via httpcore
-hf-xet==1.5.2 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.5.2 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
 html5lib==1.1
     # via
@@ -350,14 +351,13 @@ httpx==0.28.1
     #   anthropic
     #   docling-slim
     #   google-genai
-    #   huggingface-hub
     #   llama-cloud
     #   llama-index-core
     #   notion-client
     #   openai
     #   synapseclient
     #   unstructured-client
-huggingface-hub==1.13.0
+huggingface-hub==0.36.2
     # via
     #   accelerate
     #   datasets
@@ -1052,6 +1052,7 @@ requests==2.34.2
     #   google-cloud-storage
     #   google-genai
     #   goose3
+    #   huggingface-hub
     #   llama-index-core
     #   msal
     #   mwapi
@@ -1068,6 +1069,7 @@ requests==2.34.2
     #   synapseclient
     #   tiktoken
     #   tldextract
+    #   transformers
     #   tweepy
     #   unstructured
     #   youtube-transcript-api
@@ -1258,7 +1260,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-transformers==5.8.1
+transformers==4.57.6
     # via
     #   -r requirements.in
     #   docling-core
@@ -1290,8 +1292,6 @@ typer==0.15.4
     #   -r requirements.in
     #   docling-core
     #   docling-slim
-    #   huggingface-hub
-    #   transformers
 typing-extensions==4.16.0
     # via
     #   aiohttp


### PR DESCRIPTION
## Summary

Raises version floors in `requirements.in` / `requirements-extra.in` and recompiles both lockfiles with `uv pip compile` to close the open Dependabot alerts except torch and transformers (see Residual). Also fixes the PMC crawler indexing URL.

| Package | Old → New | Alert severity |
|---|---|---|
| mistune | 2.0.5 → 3.3.3 | high |
| pillow | 12.2.0 → 12.3.0 | high |
| soupsieve | 2.7 → 2.9 | high |
| nltk | 3.9.4 → 3.10.0 | high |
| pypdf | 5.6.0 → 6.14.2 | medium |
| aiohttp | 3.13.3 → 3.14.2 | medium/low |
| pyjwt | 2.12.1 → 2.13.0 | medium |
| bleach | 6.2.0 → 6.4.0 | medium |
| onnx | 1.21.0 → 1.22.0 | medium |
| pi-heif | 0.22.0 → 1.4.0 | medium |

Routine bumps with no open alert: requests 2.32.3 → 2.33.1 (2.34.2 in extra), gmft 0.4.2 → 0.4.3.

## PMC crawler fix

PMC now serves a JS interstitial at `/articles/PMC<id>/pdf/` that returns no content to non-browser clients, so the crawler was indexing nothing. It now indexes the article HTML page (`/articles/PMC<id>/`) instead.

## Residual

- **transformers stays on 4.x** (`>=4.56,<5`, resolves to 4.57.6). An upgrade to 5.8.1 was attempted and reverted: transformers 5.x strict config validation rejects the `microsoft/table-transformer` checkpoints gmft loads (`"dilation": null` fails bool validation in `from_pretrained`), which breaks `enable_gmft` table extraction entirely. This leaves CVE-2026-4372 / CVE-2026-5241 (high, RCE via malicious model `config.json`; only patched in 5.x) open. Exposure is limited — the repo has no direct transformers imports and only loads fixed, known models bundled in the image (#354). Re-raise the floor once gmft works with transformers 5.x; a note in `requirements.in` tracks this.
- **torch stays at 2.7.1.** Its open alert (CVE-2025-3000) is low severity and the fixed version (2.13.0) conflicts with the `torchvision==0.22.1` pin, so it needs its own compatibility pass for torchvision/easyocr/docling.

## Testing

- Full test suite: 633 passed against the new lockfile in a fresh venv (Python 3.12).
- pypdf 5→6: all usage is stable API (`PdfReader`, `.pages`, `PdfWriter.add_page`, `.metadata.title`).
- nltk/mistune usage checked — no direct app-code imports affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbMt57PrHn1ZED9iaxQvps
