### PR TITLE
Upgrade transformers to 5.x and huggingface-hub to 1.25.1

### DIFF
--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -51,9 +51,10 @@ charset-normalizer==3.4.2
     #   pdfminer-six
     #   requests
     #   unstructured
-click==8.1.8
+click==8.4.2
     # via
     #   -c requirements.txt
+    #   huggingface-hub
     #   nltk
     #   python-oxmsg
     #   typer
@@ -126,7 +127,6 @@ filelock==3.18.0
     #   huggingface-hub
     #   tldextract
     #   torch
-    #   transformers
 filetype==1.2.0
     # via
     #   -c requirements.txt
@@ -177,7 +177,7 @@ h11==0.16.0
     #   httpcore
 h5py==3.12.1
     # via -r requirements-extra.in
-hf-xet==1.5.2 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.5.2 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via
     #   -c requirements.txt
     #   huggingface-hub
@@ -192,9 +192,10 @@ httpcore==1.0.9
 httpx==0.28.1
     # via
     #   -c requirements.txt
+    #   huggingface-hub
     #   unstructured-client
     #   weasel
-huggingface-hub==0.36.2
+huggingface-hub==1.25.1
     # via
     #   -c requirements.txt
     #   accelerate
@@ -586,16 +587,14 @@ regex==2026.7.19
     #   nltk
     #   presidio-analyzer
     #   transformers
-requests==2.34.2
+requests==2.33.1
     # via
     #   -c requirements.txt
     #   google-api-core
-    #   huggingface-hub
     #   requests-file
     #   requests-toolbelt
     #   spacy
     #   tldextract
-    #   transformers
     #   unstructured
 requests-file==2.1.0
     # via
@@ -705,7 +704,7 @@ tqdm==4.67.1
     #   spacy
     #   transformers
     #   unstructured
-transformers==4.57.6
+transformers==5.8.1
     # via
     #   -c requirements.txt
     #   unstructured-inference
@@ -713,10 +712,11 @@ triton==3.3.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
     # via
     #   -c requirements.txt
     #   torch
-typer==0.15.4
+typer==0.21.1
     # via
     #   -c requirements.txt
     #   spacy
+    #   transformers
     #   weasel
 typing-extensions==4.16.0
     # via

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -231,7 +231,7 @@ langdetect==1.0.9
     # via
     #   -c requirements.txt
     #   unstructured
-lxml==6.1.0
+lxml==6.1.1
     # via
     #   -c requirements.txt
     #   pikepdf

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,9 @@
 requests>=2.32.4
 requests-ntlm==1.3.0
 certifi>=2024.8.30
-click==8.1.8
+# >=8.4.2 required by huggingface-hub 1.25+. Needs typer>=0.16 (0.15.x caps
+# click<8.2); typer is held <0.22 by docling-slim.
+click>=8.4.2
 authlib==1.6.11
 feedparser==6.0.11
 pyyaml>=6.0
@@ -51,18 +53,20 @@ lxml[html_clean]==6.1.0
 html5lib==1.1
 unstructured[pdf]==0.18.26
 unstructured-inference>=1.0.5
-# Capped at <5: transformers 5.x strict config validation rejects the
-# microsoft/table-transformer checkpoints gmft loads ("dilation": null fails
-# bool validation in from_pretrained), which breaks enable_gmft table
-# extraction entirely. NOTE: this reopens CVE-2026-4372 / CVE-2026-5241
-# (high, RCE via malicious model config.json; only patched in 5.3/5.5) —
-# re-raise the floor once gmft works with transformers 5.x.
-# >=4.56 required: fixes docling's dtype= kwarg forwarding (Idefics3 TypeError).
-transformers[torch]>=4.56.0,<5
+# >=5.5 required: CVE-2026-4372 / CVE-2026-5241 (high, RCE via malicious model
+# config.json). The previous <5 cap existed because transformers 5.x strict
+# config validation rejects the microsoft/table-transformer checkpoints gmft
+# loads ("dilation": null fails bool validation); gmft 0.4.4 patches that field
+# on load, so the cap is gone.
+transformers[torch]>=5.5
 safetensors[torch]>=0.6.2
 datasets==3.6.0
-torch>=2.7.1
-torchvision>=0.22.0
+# Pinned to match the CPU wheels the Dockerfile installs from
+# download.pytorch.org; a floor here lets the lock float to a newer torch,
+# which the following `pip install -r requirements.txt` would pull as GPU
+# wheels and undo the CPU-only image.
+torch==2.7.1
+torchvision==0.22.1
 pydub==0.25.1
 pytubefix==10.10.1
 youtube-transcript-api==0.6.2
@@ -80,13 +84,13 @@ easyocr>=1.7.0
 llama-parse==0.6.68
 llama-cloud-services==0.6.68
 llama-index-core==0.14.2
-gmft==0.4.3
+gmft==0.4.4
 pypdf>=6.13.3
 furl==2.1.3
 office365-rest-python-client==2.6.2
 cairosvg==2.9.0
 scrapy==2.16.0
-typer==0.15.4
+typer==0.21.1
 boxsdk[jwt]==3.10.0
 google-cloud-aiplatform==1.133.0
 nltk>=3.10.0

--- a/requirements.in
+++ b/requirements.in
@@ -49,7 +49,7 @@ openai==1.99.6
 openai-whisper==20250625
 anthropic==0.62.0
 slack-sdk==3.33.5
-lxml[html_clean]==6.1.0
+lxml[html_clean]==6.1.1
 html5lib==1.1
 unstructured[pdf]==0.18.26
 unstructured-inference>=1.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,9 +105,10 @@ charset-normalizer==3.4.2
     #   pdfminer-six
     #   requests
     #   unstructured
-click==8.1.8
+click==8.4.2
     # via
     #   -r requirements.in
+    #   huggingface-hub
     #   llama-cloud-services
     #   nltk
     #   python-oxmsg
@@ -226,7 +227,6 @@ filelock==3.18.0
     #   ray
     #   tldextract
     #   torch
-    #   transformers
 filetype==1.2.0
     # via
     #   banks
@@ -249,7 +249,7 @@ fsspec==2024.5.0
     #   torch
 furl==2.1.3
     # via -r requirements.in
-gmft==0.4.3
+gmft==0.4.4
     # via -r requirements.in
 google-api-core==2.25.0
     # via
@@ -331,7 +331,7 @@ grpcio-status==1.62.3
     # via google-api-core
 h11==0.16.0
     # via httpcore
-hf-xet==1.5.2 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.5.2 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
 html5lib==1.1
     # via
@@ -350,13 +350,14 @@ httpx==0.28.1
     #   anthropic
     #   docling-slim
     #   google-genai
+    #   huggingface-hub
     #   llama-cloud
     #   llama-index-core
     #   notion-client
     #   openai
     #   synapseclient
     #   unstructured-client
-huggingface-hub==0.36.2
+huggingface-hub==1.25.1
     # via
     #   accelerate
     #   datasets
@@ -1055,7 +1056,6 @@ requests==2.33.1
     #   google-cloud-storage
     #   google-genai
     #   goose3
-    #   huggingface-hub
     #   llama-index-core
     #   msal
     #   mwapi
@@ -1072,7 +1072,6 @@ requests==2.33.1
     #   synapseclient
     #   tiktoken
     #   tldextract
-    #   transformers
     #   tweepy
     #   unstructured
     #   youtube-transcript-api
@@ -1235,6 +1234,7 @@ torchvision==0.22.1
     #   docling-slim
     #   easyocr
     #   effdet
+    #   gmft
     #   timm
 tornado==6.5.7
     # via
@@ -1263,7 +1263,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-transformers==4.57.6
+transformers==5.8.1
     # via
     #   -r requirements.in
     #   docling-core
@@ -1290,11 +1290,12 @@ twisted==26.4.0
     # via
     #   -r requirements.in
     #   scrapy
-typer==0.15.4
+typer==0.21.1
     # via
     #   -r requirements.in
     #   docling-core
     #   docling-slim
+    #   transformers
 typing-extensions==4.16.0
     # via
     #   aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -465,7 +465,7 @@ llama-parse==0.6.68
     # via -r requirements.in
 llvmlite==0.47.0
     # via numba
-lxml==6.1.0
+lxml==6.1.1
     # via
     #   -r requirements.in
     #   arxiv
@@ -479,7 +479,7 @@ lxml==6.1.0
     #   python-pptx
     #   scrapy
     #   unstructured
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.5
     # via lxml
 markdown==3.8.2
     # via -r requirements.in

--- a/tests/test_pmc_crawler.py
+++ b/tests/test_pmc_crawler.py
@@ -37,9 +37,11 @@ def make_crawler():
 
 class TestPmcPaperIndexing(unittest.TestCase):
 
-    def test_pdf_url_uses_current_pmc_domain(self):
+    def test_indexes_article_html_on_current_pmc_domain(self):
         # Regression: www.ncbi.nlm.nih.gov/pmc/... now 301s to
-        # pmc.ncbi.nlm.nih.gov; the crawler must use the current domain.
+        # pmc.ncbi.nlm.nih.gov, and /pdf/ serves a JS interstitial with no
+        # content for non-browser clients, so the crawler must index the
+        # article HTML page on the current domain.
         crawler = make_crawler()
         with patch("crawlers.pmc_crawler.get_top_n_papers",
                    return_value=["123"]):
@@ -48,7 +50,7 @@ class TestPmcPaperIndexing(unittest.TestCase):
         crawler.indexer.index_url.assert_called_once()
         indexed_url = crawler.indexer.index_url.call_args.args[0]
         self.assertEqual(
-            indexed_url, "https://pmc.ncbi.nlm.nih.gov/articles/PMC123/pdf/")
+            indexed_url, "https://pmc.ncbi.nlm.nih.gov/articles/PMC123/")
 
     def test_index_url_failure_is_logged(self):
         # Regression: index_url's return value was discarded, so per-paper


### PR DESCRIPTION
## What

Lifts the `transformers<5` cap, moves `huggingface-hub` to the latest release, and picks up the patched `lxml-html-clean`.

| package | before | after |
|---|---|---|
| gmft | 0.4.3 | 0.4.4 |
| transformers | 4.57.6 | 5.8.1 |
| huggingface-hub | 0.36.2 | 1.25.1 |
| click | 8.1.8 | 8.4.2 |
| typer | 0.15.4 | 0.21.1 |
| lxml-html-clean | 0.4.2 | 0.4.5 |
| lxml | 6.1.0 | 6.1.1 |
| torch / torchvision | `>=` floors | `==` pins (2.7.1 / 0.22.1, unchanged) |

Also fixes `tests/test_pmc_crawler.py`, which has been failing on `main` since 37df7e7.

## Why

**transformers.** The `<5` cap existed because transformers 5.x strict config validation rejects the `microsoft/table-transformer-*` checkpoints gmft loads — `"dilation": null` fails `bool` validation and `enable_gmft` table extraction dies with `StrictDataclassFieldValidationError`. gmft 0.4.4 added `_load_tatr_from_pretrained`, which patches that field on load. The cap is no longer needed, and lifting it closes CVE-2026-4372 / CVE-2026-5241 (high, RCE via a malicious model `config.json`), patched in 5.3/5.5.

**Why 5.8.1 and not 5.14.1.** `docling-core` and `docling-ibm-models` cap `transformers<5.9.0` on darwin. Resolving past that forces `docling-core` down to 2.78.0 on macOS and `docling-ibm-models` to 3.13.2. 5.8.1 is above the CVE floor and leaves docling where it is; worth revisiting when docling lifts its own cap.

**click / typer.** `huggingface-hub>=1.25` requires `click>=8.4.2`; `typer==0.15.4` requires `click<8.2`. typer 0.21.1 drops that cap and stays under docling-slim's `typer<0.22`.

**lxml-html-clean / lxml.** 0.4.2 is vulnerable to GHSA-xvp8-3mhv-424c (`<base>` tag injection through the default `Cleaner` config) and GHSA-hw26-mmpg-fqfg (CSS `@import` filter bypass via unicode escapes), both moderate and both patched in 0.4.4. This takes 0.4.5, the current release, which declares `lxml>=6.1.1` — hence the `lxml[html_clean]` pin in `requirements.in` moving from 6.1.0 to 6.1.1. It reaches us through the `lxml[html_clean]` extra in `requirements.in`; the actual consumer is `justext`, whose `justext.core` imports `lxml.html.clean.Cleaner` and which `core/extract.py` uses on every crawled HTML page.

**torch / torchvision.** These were floors (`>=2.7.1`, `>=0.22.0`), so the lock was free to resolve a newer torch. The Dockerfile installs `torch==2.7.1 torchvision==0.22.1` from `download.pytorch.org/whl/cpu` and then runs `uv pip install -r requirements.txt`, which would have pulled the default GPU wheels over the CPU ones. Pinning the lock to the versions the Dockerfile already installs keeps that from happening.

**PMC test.** 37df7e7 changed `crawlers/pmc_crawler.py` to index `https://pmc.ncbi.nlm.nih.gov/articles/PMC{id}/` instead of `.../pdf/` (the `/pdf/` path serves a JS interstitial with no content for non-browser clients) but did not update the test, which still asserted the `/pdf/` URL.

## Verification

gmft table extraction run end to end on the resolved stack (gmft 0.4.4, transformers 5.8.1, huggingface-hub 1.25.1, torch 2.7.1) against a PDF with 5 tables — both TATR models load through the new compatibility path (`Applying compatibility workaround for transformers 5.x`) and all 5 tables extract with correct shapes and cell contents. The same script against gmft 0.4.3 on transformers 5.x fails with `Field 'dilation' expected bool, got NoneType`.

Full unit suite on the new lock (Python 3.11): **550 tests, all passing**. `make lint` passes. Note: that run predates the `lxml` / `lxml-html-clean` bump; re-running against the current lock before merge.
