### PR TITLE
fix(run.sh): honor YAML boolean flags and abort on bad crawler_file

### DIFF
--- a/config/box-example.yaml
+++ b/config/box-example.yaml
@@ -19,9 +19,8 @@ doc_processing:
   process_locally: true
 
   # Table handling
-  parse_tables: true           # Extract tables from PDFs
+  parse_tables: true           # Extract and summarize tables (summarization needs model_config)
   enable_gmft: false           # Disable GMFT to avoid OpenAI costs
-  summarize_tables: false      # Set to true to enable AI summarization (requires model config)
 
   # Image handling
   summarize_images: false      # Set to true to enable AI summarization (requires model config)

--- a/docs/box/BOX_INGESTION_GUIDE.md
+++ b/docs/box/BOX_INGESTION_GUIDE.md
@@ -43,8 +43,7 @@ vectara:
   output_dir: /tmp/box_inspection     # Where failed files go
 
 doc_processing:
-  parse_tables: true                  # Extract tables from PDFs
-  summarize_tables: false             # Skip AI table summarization
+  parse_tables: true                  # Extract and summarize tables from PDFs
   summarize_images: false             # Skip AI image summarization
 
 box_crawler:

--- a/docs/vertex-ai/README.md
+++ b/docs/vertex-ai/README.md
@@ -29,7 +29,7 @@ Vertex AI integration enables AI-powered table and image summarization during do
 
 ```yaml
 doc_processing:
-  summarize_tables: true
+  parse_tables: true      # extracts AND summarizes tables
   summarize_images: true
 
 table_model_config:

--- a/docs/vertex-ai/VERTEX_AI_SETUP.md
+++ b/docs/vertex-ai/VERTEX_AI_SETUP.md
@@ -112,10 +112,12 @@ vectara:
 crawling:
   crawler_type: folder
 
+doc_processing:
+  parse_tables: true      # extracts AND summarizes tables
+  summarize_images: true
+
 folder_crawler:
   path: /path/to/documents
-  summarize_tables: true
-  summarize_images: true
 ```
 
 ### Example 2: Mix OpenAI and Vertex AI
@@ -143,10 +145,12 @@ vectara:
     model_name: gemini-1.5-flash-002
     location: us-central1
 
+doc_processing:
+  parse_tables: true      # extracts AND summarizes tables
+  summarize_images: true
+
 folder_crawler:
   path: /path/to/documents
-  summarize_tables: true
-  summarize_images: true
 ```
 
 ### Example 3: High-Quality Processing for Complex Documents
@@ -170,10 +174,12 @@ vectara:
     model_name: gemini-1.5-pro-002
     location: us-central1
 
+doc_processing:
+  parse_tables: true      # extracts AND summarizes tables
+  summarize_images: true
+
 folder_crawler:
   path: /path/to/technical_docs
-  summarize_tables: true
-  summarize_images: true
 ```
 
 ### Example 4: Budget-Friendly with Experimental Model

--- a/run.sh
+++ b/run.sh
@@ -107,8 +107,12 @@ get_custom_crawler_path() {
   echo "$(realpath "$custom_crawler")"
 }
 
-# Get custom crawler path (empty if not specified)
-CUSTOM_CRAWLER_PATH=$(get_custom_crawler_path)
+# Get custom crawler path (empty if not specified).
+# `|| exit $?` is required: get_custom_crawler_path runs in a command
+# substitution, so its `exit` only ends the subshell. Without this the script
+# continued past a missing/misnamed crawler_file and launched the container with
+# the BUILT-IN crawler instead — a silently wrong ingest that exited 0.
+CUSTOM_CRAWLER_PATH=$(get_custom_crawler_path) || exit $?
 
 # Validate crawler exists (either custom or built-in)
 if [[ -z "$CUSTOM_CRAWLER_PATH" ]]; then
@@ -165,20 +169,26 @@ if [[ "${DOWNLOAD_DOCLING_MODELS}" == "true" ]]; then
 fi
 
 
-# Read config values for extra features
-sum_tables=$(read_yaml_nested "data.get('doc_processing', {}).get('summarize_tables', 'false').lower()")
-sum_images=$(read_yaml_nested "data.get('doc_processing', {}).get('summarize_images', 'false').lower()")
-mask_pii=$(read_yaml_nested "data.get('vectara', {}).get('mask_pii', 'false').lower()")
+# Read config values for extra features.
+# str(...) before .lower() is required: YAML parses `true` as a bool, and
+# bool has no .lower(), so read_yaml_nested swallowed the AttributeError and
+# returned "" — meaning `mask_pii: true` silently built the BASE image without
+# presidio, and masking no-opped while the PII got indexed. Only a quoted
+# "true" used to work.
+sum_images=$(read_yaml_nested "str(data.get('doc_processing', {}).get('summarize_images', 'false')).lower()")
+mask_pii=$(read_yaml_nested "str(data.get('vectara', {}).get('mask_pii', 'false')).lower()")
 output_dir=$(read_yaml_nested "data.get('vectara', {}).get('output_dir', 'vectara_ingest_output')")
 
-# Determine if extra features are needed
+# Determine if extra features are needed.
+# Not keyed on summarize_tables: no code reads that key (parse_tables is the
+# real switch), and table summarization needs nothing from requirements-extra.
 needs_extra_features() {
-  [[ "$sum_tables" == "true" || "$sum_images" == "true" || "$mask_pii" == "true" ]]
+  [[ "$sum_images" == "true" || "$mask_pii" == "true" ]]
 }
 
 if needs_extra_features; then
   tag="vectara-ingest-full"
-  echo "Building with extra features (summarize_tables=$sum_tables, summarize_images=$sum_images, mask_pii=$mask_pii)"
+  echo "Building with extra features (summarize_images=$sum_images, mask_pii=$mask_pii)"
 else
   tag="vectara-ingest"
   echo "Building base image"

--- a/tests/test_run_sh.py
+++ b/tests/test_run_sh.py
@@ -1,0 +1,118 @@
+"""run.sh behaviour that no Python test covers.
+
+Runs the real run.sh with a stubbed `docker` on PATH, so these need no Docker
+daemon and never build an image or start a container. What they pin:
+
+- Feature flags written as YAML booleans must select the right image. `.lower()`
+  on a parsed bool raises AttributeError, and read_yaml_nested swallows it
+  (`2>/dev/null || echo ""`), so `mask_pii: true` used to build the BASE image
+  with no presidio — masking then no-opped after one log warning and the PII got
+  indexed. Only a quoted "true" worked.
+- A missing or misnamed `crawler_file` must stop the run. `exit` inside
+  `$(get_custom_crawler_path)` only ends the subshell, so run.sh used to print
+  the error and launch the container anyway with the BUILT-IN crawler.
+- `summarize_tables` is not a switch: no Python reads it (`parse_tables` is the
+  real one), so it must not drive the image choice either.
+"""
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Prints its argv and succeeds, so run.sh's buildx probe, build, and run all
+# "work" instantly and the tag it chose shows up on stdout.
+DOCKER_STUB = '#!/bin/sh\necho "docker $@"\nexit 0\n'
+
+
+class RunShTestCase(unittest.TestCase):
+
+    def run_script(self, config_text, env=None, data_dir_key=None):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            bindir = tmp / "bin"
+            bindir.mkdir()
+            stub = bindir / "docker"
+            stub.write_text(DOCKER_STUB)
+            stub.chmod(0o755)
+
+            config = tmp / "config.yaml"
+            config.write_text(config_text.replace("__TMP__", str(tmp)))
+            secrets = tmp / "secrets.toml"
+            secrets.write_text('[default]\napi_key = "abc"\n')
+
+            environ = {**os.environ,
+                       "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+                       "SECRETS_FILE": str(secrets)}
+            environ.update(env or {})
+            return subprocess.run(["bash", "run.sh", str(config), "default"],
+                                  cwd=str(REPO), capture_output=True, text=True,
+                                  timeout=180, env=environ)
+
+    @staticmethod
+    def folder_config(extra_vectara="", extra_processing=""):
+        return (f"vectara:\n"
+                f"  corpus_key: test-corpus\n{extra_vectara}"
+                f"crawling:\n"
+                f"  crawler_type: folder\n"
+                f"doc_processing:\n"
+                f"  parse_tables: true\n{extra_processing}"
+                f"folder_crawler:\n"
+                f"  path: __TMP__\n"
+                f"  extensions: ['.pdf']\n")
+
+    def test_base_image_when_no_extra_features(self):
+        res = self.run_script(self.folder_config())
+        self.assertIn('INSTALL_EXTRA="false"', res.stdout)
+        self.assertIn("vectara-ingest:latest", res.stdout)
+
+    def test_mask_pii_yaml_boolean_selects_full_image(self):
+        # `mask_pii: true`, unquoted — the form every example config uses.
+        res = self.run_script(self.folder_config(extra_vectara="  mask_pii: true\n"))
+        self.assertIn('INSTALL_EXTRA="true"', res.stdout)
+        self.assertIn("vectara-ingest-full:latest", res.stdout)
+
+    def test_summarize_images_yaml_boolean_selects_full_image(self):
+        res = self.run_script(
+            self.folder_config(extra_processing="  summarize_images: true\n"))
+        self.assertIn('INSTALL_EXTRA="true"', res.stdout)
+        self.assertIn("vectara-ingest-full:latest", res.stdout)
+
+    def test_quoted_true_still_works(self):
+        res = self.run_script(self.folder_config(extra_vectara='  mask_pii: "true"\n'))
+        self.assertIn('INSTALL_EXTRA="true"', res.stdout)
+
+    def test_summarize_tables_does_not_select_full_image(self):
+        # Not a real switch — no Python reads it; parse_tables is the one that
+        # drives table extraction and summarization.
+        res = self.run_script(
+            self.folder_config(extra_processing="  summarize_tables: true\n"))
+        self.assertIn('INSTALL_EXTRA="false"', res.stdout)
+
+    def test_download_docling_models_uses_onprem_tag(self):
+        res = self.run_script(self.folder_config(),
+                              env={"DOWNLOAD_DOCLING_MODELS": "true"})
+        self.assertIn("latest.onprem", res.stdout)
+        self.assertIn("--build-arg DOWNLOAD_DOCLING_MODELS=true", res.stdout)
+
+    def test_missing_custom_crawler_aborts(self):
+        res = self.run_script(
+            self.folder_config(extra_vectara="  crawler_file: /nonexistent/folder_crawler.py\n"))
+        self.assertEqual(res.returncode, 9, res.stdout + res.stderr)
+        # The real damage was continuing past the error with the built-in crawler.
+        self.assertNotIn("Running docker:", res.stdout)
+
+    def test_misnamed_custom_crawler_aborts(self):
+        with tempfile.TemporaryDirectory() as crawler_dir:
+            wrong = Path(crawler_dir) / "wrong_crawler.py"
+            wrong.write_text("class WrongCrawler(Crawler):\n    pass\n")
+            res = self.run_script(
+                self.folder_config(extra_vectara=f"  crawler_file: {wrong}\n"))
+        self.assertEqual(res.returncode, 10, res.stdout + res.stderr)
+        self.assertNotIn("Running docker:", res.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three defects in `run.sh`, all silent — each produced a working-looking run that did the wrong thing. Found while building end-to-end coverage for the container build options.

## 1. Feature flags could not be read as YAML booleans

```bash
mask_pii=$(read_yaml_nested "data.get('vectara', {}).get('mask_pii', 'false').lower()")
```

`yaml.safe_load` turns `true` into a Python **bool**, which has no `.lower()`. The `AttributeError` is swallowed by the helper's `2>/dev/null || echo ""`, so the flag comes back empty and `needs_extra_features` sees nothing. Only a quoted `"true"` ever worked.

Consequence: `mask_pii: true` built the **base** image with `INSTALL_EXTRA=false`. `presidio-analyzer` lives in `requirements-extra.txt`, so `PRESIDIO_AVAILABLE` was false and `mask_pii()` returned the text unchanged after one log warning — **the PII got indexed**.

Reproduced end to end before the fix:

```
Building base image
docker buildx build --load --build-arg INSTALL_EXTRA="false" ... --tag="vectara-ingest:latest"
core.utils - WARNING - Presidio is not installed. PII masking is disabled.
```

with the SSN, credit card, and email all landing in the corpus. Fixed with `str(...)` before `.lower()`.

## 2. A missing or misnamed `crawler_file` did not stop the run

```bash
CUSTOM_CRAWLER_PATH=$(get_custom_crawler_path)
```

`get_custom_crawler_path` runs in a command substitution, so its `exit 9` / `exit 10` only ended the subshell. `run.sh` printed the error and then **launched the container anyway using the built-in crawler**, exiting 0 — a typo in `crawler_file` gave a silently wrong ingest. Codes 9 and 10 were unreachable.

Fixed with `|| exit $?` so the status propagates.

## 3. `summarize_tables` drove the image choice but is read by nothing

No Python reads `doc_processing.summarize_tables` — `parse_tables` is the real switch (`core/file_processor.py`, `core/indexer.py`, `core/doc_parser.py`). Table summarization also needs nothing from `requirements-extra`. Dropped from `needs_extra_features`, and corrected in `config/box-example.yaml` and the Box/Vertex docs, where three Vertex examples additionally had it — and `summarize_images` — nested under `folder_crawler` instead of `doc_processing`.

## Tests

Adds `tests/test_run_sh.py`: drives the real script with a stubbed `docker` on `PATH`, so it needs no daemon and never builds an image or starts a container (8 checks, ~4s).

- **4 of the 8 fail against the previous `run.sh`**, all 8 pass after.
- Full suite: 637 passed, 1 pre-existing failure (`test_pmc_crawler::test_pdf_url_uses_current_pmc_domain`, fails identically on clean `main`).
- `ruff` clean, `bash -n run.sh` clean.

Also verified against the end-to-end regression suite: `mask_pii: true` now selects `vectara-ingest-full` and masks SSN/card/email while leaving non-PII intact; exit codes 9 and 10 now fire without launching a container; and the image/table cases that switch to the full image for the first time as a result (`image-png`, `pdf-local`) still pass, as do the deterministic snapshot cases (`csv-got`, `folder-pdf`, `bulkupload`) with no drift.