### PR TITLE
fix(tests): update stale PMC URL assertion, run unit tests on main

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -2,6 +2,11 @@ name: Run Python Unit Tests
 
 on:
   pull_request: # Triggers on pull requests to any branch by default when 'branches' is omitted
+  # Also run on main. Without this the suite only ever ran pre-merge, so a merged
+  # PR could leave main red and nobody would see it until the next PR opened —
+  # which is exactly how the stale PMC URL assertion went unnoticed.
+  push:
+    branches: [main]
 
 jobs:
   test:

--- a/tests/test_pmc_crawler.py
+++ b/tests/test_pmc_crawler.py
@@ -37,9 +37,11 @@ def make_crawler():
 
 class TestPmcPaperIndexing(unittest.TestCase):
 
-    def test_pdf_url_uses_current_pmc_domain(self):
+    def test_article_url_uses_current_pmc_domain(self):
         # Regression: www.ncbi.nlm.nih.gov/pmc/... now 301s to
         # pmc.ncbi.nlm.nih.gov; the crawler must use the current domain.
+        # The path is the article HTML page, not /pdf/ — PMC serves a JS
+        # interstitial there that yields no content (see pmc_crawler.py).
         crawler = make_crawler()
         with patch("crawlers.pmc_crawler.get_top_n_papers",
                    return_value=["123"]):
@@ -48,7 +50,7 @@ class TestPmcPaperIndexing(unittest.TestCase):
         crawler.indexer.index_url.assert_called_once()
         indexed_url = crawler.indexer.index_url.call_args.args[0]
         self.assertEqual(
-            indexed_url, "https://pmc.ncbi.nlm.nih.gov/articles/PMC123/pdf/")
+            indexed_url, "https://pmc.ncbi.nlm.nih.gov/articles/PMC123/")
 
     def test_index_url_failure_is_logged(self):
         # Regression: index_url's return value was discarded, so per-paper


### PR DESCRIPTION
`main` is currently red, and has been since #361.

## The stale assertion

#361 deliberately changed the PMC crawler to index the article HTML page instead of `/pdf/`:

```diff
-            pdf_url = f"https://pmc.ncbi.nlm.nih.gov/articles/PMC{pmc_id}/pdf/"
+            # PMC serves a JS interstitial at /pdf/ that yields no content for
+            # non-browser clients, so index the article HTML page instead.
+            article_url = f"https://pmc.ncbi.nlm.nih.gov/articles/PMC{pmc_id}/"
```

It didn't update `tests/test_pmc_crawler.py`, which still asserts the `/pdf/` URL. `git log` shows the drift plainly: `crawlers/pmc_crawler.py` last changed in `37df7e7` (#361), `tests/test_pmc_crawler.py` last changed in `66fe18d` (#359).

The test is the side that's wrong — the crawler change is intentional and carries its rationale in a comment. The test was also over-specified relative to its own purpose: its comment says it guards the `www.ncbi.nlm.nih.gov` → `pmc.ncbi.nlm.nih.gov` domain migration, and that half never stopped passing. Pinning the full URL string is what made it brittle. Renamed from `test_pdf_url_uses_current_pmc_domain` to `test_article_url_uses_current_pmc_domain` so the name matches what it actually checks.

## Why it went unnoticed

`.github/workflows/python-tests.yml` triggered on `pull_request` only — no `push`. The suite therefore never ran on `main`, so a merged PR could leave it red indefinitely; `gh run list --branch main` shows only Dependency Graph and Create Release runs. It only resurfaces when the next PR opens, which is how this was found (from #363).

Added `push: branches: [main]` so this can't repeat.

## Verification

- `python -m pytest tests/` → 630 passed, 1 skipped, 0 failures (the skip is `test_box_crawler`, which `importorskip`s `boxsdk`).
- Ruff clean.

Splitting this out of #363 to keep that diff focused on the `run.sh` fixes.