### PR TITLE
fix(ci): call conda-build executable instead of `conda build`

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -51,7 +51,10 @@ jobs:
       - name: Run conda build in dry-run mode
         shell: bash -l {0}
         run: |
-          conda build --check conda
+          # Use the conda-build executable, not `conda build`: the `conda` shell
+          # function always runs the base env's binary, which can't see the
+          # conda-build plugin installed in the activated env.
+          conda-build --check conda
 
   build-and-publish:
     name: Build and Publish on ${{ matrix.os == 'macos-latest' && 'macOS' || 'Windows' }}
@@ -108,7 +111,7 @@ jobs:
           # Verify Python version before building
           python --version
           # Use conda-build with Git versioning
-          conda build --channel conda-forge conda --output-folder ./conda-bld
+          conda-build --channel conda-forge conda --output-folder ./conda-bld
           
       - name: Post-build cleanup
         uses: ./.github/actions/conda-cleanup
@@ -247,7 +250,7 @@ jobs:
           # Verify Python version before building
           python --version
           # Use conda-build with Git versioning
-          conda build --channel conda-forge conda --output-folder ./conda-bld
+          conda-build --channel conda-forge conda --output-folder ./conda-bld
           
       - name: Post-build cleanup
         run: |


### PR DESCRIPTION
## Problem

The **Build and Publish Conda Package** workflow fails at the first step of the lint job, on every release (2.13.2, 2.13.1, 2.13.0, and every retained run before that):

```
conda: error: argument COMMAND: invalid choice: 'build' (choose from 'activate', 'check', ...)
```

## Cause

`conda` is a shell function that always dispatches to `$CONDA_EXE` — the **base** environment's binary — regardless of which environment is active. `conda build` is a plugin subcommand, so it only registers when `conda-build` is installed in that same environment.

`setup-miniconda` activates env `test`, and the workflow runs `conda install -y conda-build`, which lands in `envs/test`. Base conda never sees the plugin.

It used to work because older conda fell back to finding a `conda-build` executable on `PATH`. conda 26.x removed executable-based subcommand discovery, so the fallback is gone — nothing in this repo changed.

## Fix

Call the `conda-build` console script, which lives in whichever environment has conda-build installed. Applied to all three build jobs so the invocation is uniform (the Red Hat job installs into base, so it was already working).

## Verification

Reproduced and fixed in a `linux/amd64 continuumio/miniconda3` container resolving the same versions CI does (conda 26.5.3, conda-build 26.5.0):

- `conda build --check conda` → reproduces the error above
- `conda-build --check conda` → exit 0 against this repo's `conda/` recipe

The dry-run check is what gates the pipeline; the full package build on macOS/Windows/RHEL uses the same executable and will be exercised by the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DRCwnVNxd5e6ECwekDY73