### PR TITLE
fix(conda): drop nonexistent chromium dep and unavailable ffmpeg rpm

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -193,9 +193,10 @@ jobs:
           # Install build dependencies
           yum install -y git wget make gcc
 
-          # Core dependencies
+          # Core dependencies (no ffmpeg: not in the CentOS Stream 9 repos, and the
+          # package already gets it from conda-forge)
           yum install -y alsa-lib gtk3 libX11-xcb libXcomposite libXcursor libXdamage \
-            libXext libXi libXrandr libXtst mesa-libgbm pango cups-libs ffmpeg
+            libXext libXi libXrandr libXtst mesa-libgbm pango cups-libs
 
           # Fonts
           yum install -y liberation-fonts dejavu-sans-fonts

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -44,7 +44,8 @@ requirements:
     - conda-forge::libgl  # [linux]
     
     # System dependencies with conda-forge channel specified
-    - conda-forge::chromium
+    # No chromium here: Playwright downloads and launches its own browser
+    # (see core/web_content_extractor.py), and conda-forge has no chromium package.
     - conda-forge::poppler
     - conda-forge::tesseract
     - conda-forge::libjpeg-turbo


### PR DESCRIPTION
## Problem

The conda package has never been built successfully. Every run of **Build and Publish Conda Package** has failed, going back at least to Release 2.6.0 in January 2026 (20 retained runs, zero successes).

#365 fixed the first failure — `conda: error: argument COMMAND: invalid choice: 'build'` — and the lint job now passes for the first time. A dispatch on `main` for version 2.13.2 ([run 30457881815](https://github.com/vectara/vectara-ingest/actions/runs/30457881815)) got past lint and exposed two blockers behind it.

### 1. `conda-forge::chromium` does not exist

```
Unsatisfiable dependencies for platform osx-arm64: {MatchSpec("chromium")}
Unsatisfiable dependencies for platform win-64:   {MatchSpec("chromium")}
```

There is no `chromium` package on conda-forge for any platform. A search of anaconda.org turns up only `ESSS/chromium` (an unrelated third-party channel, linux-64) and `bioconda/r-chromium` (an R package). The dependency was unsatisfiable on linux-64 too — the Red Hat job just failed earlier, on the ffmpeg problem below, and never reached the solve.

Nothing uses it. The crawlers launch Playwright's own bundled browser:

- `core/web_content_extractor.py:61` — `self.p.chromium.launch(...)` under `sync_playwright()`
- `Dockerfile:81` and `WINDOWS_INSTALLATION_GUIDE.md:93` — `playwright install chromium`

Playwright downloads Chromium into `~/.cache/ms-playwright` and launches it from there; a conda-provided binary would never be consulted.

This stayed hidden because the lint job runs `conda-build --check`, which only parses the recipe. Dependencies are not solved until the build itself.

### 2. `ffmpeg` is not in the CentOS Stream 9 repos

The Red Hat job fails at `Install system dependencies`:

```
No match for argument: ffmpeg
Error: Unable to find a match: ffmpeg
```

On CentOS Stream 9, ffmpeg comes from RPM Fusion, not base/appstream. Checked in `quay.io/centos/centos:stream9`: the other 15 packages on that line all resolve, ffmpeg alone does not. It arrived with 3921977 (Improve Edgar Crawler, #273). The package already declares `conda-forge::ffmpeg` as a run dependency, so the rpm is not needed for the build.

## Fix

Remove `conda-forge::chromium` from the recipe's run requirements, and drop `ffmpeg` from the Red Hat job's `yum install`.

## Verification

Against conda-forge in a `linux/amd64 continuumio/miniconda3` container:

- `CONDA_SUBDIR=<plat> conda create --dry-run` over the remaining run requirements solves cleanly for **osx-arm64**, **win-64** and **linux-64** (the linux-only entries included for the last one). Re-adding `chromium` fails all three.
- `conda-build --check conda` still exits 0.
- `yum list` in `quay.io/centos/centos:stream9` confirms every remaining package on the trimmed line is available.

The full build and the recipe's `test:` section have never run to completion in CI, so more issues may surface downstream. This clears the two that are provably blocking today.