### PR TITLE
fix(build): stop shipping the CUDA stack in conda and Docker, repair the Windows recipe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,18 @@ WORKDIR ${HOME}
 COPY requirements.txt requirements-extra.txt $HOME/
 
 RUN pip install --no-cache-dir uv==0.6.14
-RUN uv pip install --no-cache-dir torch==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cpu \
-    && uv pip install --no-cache-dir -r requirements.txt
+# Take the torch pins from requirements.txt rather than repeating them here:
+# hardcoded copies go stale on a lock bump, and the newer torch then comes from
+# PyPI as the CUDA build. The final check fails the build if that happens --
+# CUDA wheels are ~2 GB and nothing loads them (CUDA_VISIBLE_DEVICES="").
+RUN TORCH_PINS="$(grep -E '^(torch|torchvision)==' requirements.txt)" \
+    && test -n "$TORCH_PINS" \
+    && uv pip install --no-cache-dir $TORCH_PINS --index-url https://download.pytorch.org/whl/cpu \
+    && uv pip install --no-cache-dir -r requirements.txt \
+    && if pip list --format=freeze | grep '^nvidia-'; then \
+           echo "ERROR: CUDA wheels installed above -- CPU torch was overridden" >&2; \
+           exit 1; \
+       fi
 
 ARG INSTALL_EXTRA=false
 RUN if [ "$INSTALL_EXTRA" = "true" ]; then \

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -9,4 +9,4 @@ set PIP_NO_DEPENDENCIES=
 
 :: Windows torch wheels on PyPI are already CPU-only, so no separate index.
 "%PYTHON%" -m pip install --no-cache-dir --index-url https://pypi.org/simple .
-if errorlevel 1 exit 1
+if errorlevel 1 exit /b 1

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -6,6 +6,7 @@
 :: and win-64 shipped ~0.9 MB packages instead of ~600 MB ones.
 set PIP_NO_INDEX=
 set PIP_NO_DEPENDENCIES=
+set PIP_IGNORE_INSTALLED=
 
 :: Windows torch wheels on PyPI are already CPU-only, so no separate index.
 "%PYTHON%" -m pip install --no-cache-dir --index-url https://pypi.org/simple .

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -1,0 +1,12 @@
+@echo off
+:: conda-build sets these to stop pip from reaching the network. This recipe
+:: deliberately vendors its Python dependencies from PyPI, so clear them.
+:: `unset` is a shell builtin and does not exist in cmd.exe -- calling it here
+:: left both variables set, so pip installed the project with no dependencies
+:: and win-64 shipped ~0.9 MB packages instead of ~600 MB ones.
+set PIP_NO_INDEX=
+set PIP_NO_DEPENDENCIES=
+
+:: Windows torch wheels on PyPI are already CPU-only, so no separate index.
+"%PYTHON%" -m pip install --no-cache-dir --index-url https://pypi.org/simple .
+if errorlevel 1 exit 1

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# conda-build sets these to stop pip from reaching the network. This recipe
+# deliberately vendors its Python dependencies from PyPI, so clear them.
+unset PIP_NO_INDEX PIP_NO_DEPENDENCIES
+
+# PyPI's linux torch wheel is the CUDA build: ~820 MB of torch plus ~2 GB of
+# nvidia-* wheels, all of which ends up inside the package. Install the CPU
+# build first, the same way Dockerfile does; the later `pip install .` then
+# sees the pins already satisfied. Read the pins from requirements.txt so they
+# can't drift out of sync and silently pull CUDA back in.
+if [ "$(uname)" = "Linux" ]; then
+  torch_pins=$(grep -E '^(torch|torchvision)==' requirements.txt)
+  # shellcheck disable=SC2086  # word splitting is intended
+  "${PYTHON}" -m pip install --no-cache-dir $torch_pins \
+    --index-url https://download.pytorch.org/whl/cpu
+fi
+
+"${PYTHON}" -m pip install --no-cache-dir --index-url https://pypi.org/simple .

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -24,3 +24,13 @@ if [ "$(uname)" = "Linux" ]; then
 fi
 
 "${PYTHON}" -m pip install --no-cache-dir --index-url https://pypi.org/simple .
+
+# The CPU install above only holds if nothing re-resolved torch on the way
+# through the project's own dependencies. Assert it here: a silent fallback to
+# the CUDA wheels adds ~2.8 GB and is otherwise not visible until the upload
+# fails, an hour later.
+if "${PYTHON}" -m pip list --format=freeze | grep -q '^nvidia-'; then
+  echo "ERROR: CUDA wheels present after install -- CPU torch was overridden:" >&2
+  "${PYTHON}" -m pip list --format=freeze | grep '^nvidia-' >&2
+  exit 1
+fi

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -11,7 +11,13 @@ unset PIP_NO_INDEX PIP_NO_DEPENDENCIES
 # sees the pins already satisfied. Read the pins from requirements.txt so they
 # can't drift out of sync and silently pull CUDA back in.
 if [ "$(uname)" = "Linux" ]; then
-  torch_pins=$(grep -E '^(torch|torchvision)==' requirements.txt)
+  torch_pins=$(grep -E '^(torch|torchvision)==' requirements.txt) || true
+  if [ -z "$torch_pins" ]; then
+    echo "ERROR: no torch/torchvision== pins found in requirements.txt." >&2
+    echo "       Without them pip resolves torch from PyPI and bundles the" >&2
+    echo "       CUDA stack, adding ~2.8 GB to the package. Refusing to build." >&2
+    exit 1
+  fi
   # shellcheck disable=SC2086  # word splitting is intended
   "${PYTHON}" -m pip install --no-cache-dir $torch_pins \
     --index-url https://download.pytorch.org/whl/cpu

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-# conda-build sets these to stop pip from reaching the network. This recipe
-# deliberately vendors its Python dependencies from PyPI, so clear them.
-unset PIP_NO_INDEX PIP_NO_DEPENDENCIES
+# conda-build sets these to stop pip from reaching the network and to force a
+# clean install. This recipe deliberately vendors its Python dependencies from
+# PyPI, so clear them. PIP_IGNORE_INSTALLED matters as much as the other two:
+# left set, pip ignores the CPU torch installed below and re-resolves
+# torch==2.7.1 from PyPI, which is the CUDA build.
+unset PIP_NO_INDEX PIP_NO_DEPENDENCIES PIP_IGNORE_INSTALLED
 
 # PyPI's linux torch wheel is the CUDA build: ~820 MB of torch plus ~2 GB of
 # nvidia-* wheels, all of which ends up inside the package. Install the CPU
@@ -29,8 +32,14 @@ fi
 # through the project's own dependencies. Assert it here: a silent fallback to
 # the CUDA wheels adds ~2.8 GB and is otherwise not visible until the upload
 # fails, an hour later.
-if "${PYTHON}" -m pip list --format=freeze | grep -q '^nvidia-'; then
+# Read the list fully before filtering: `pip list | grep -q` makes grep exit on
+# the first match, pip then dies flushing to a closed pipe (exit 120), and with
+# `pipefail` the whole test reads false -- skipping the guard in exactly the
+# case it exists to catch.
+installed=$("${PYTHON}" -m pip list --format=freeze)
+cuda_wheels=$(printf '%s\n' "$installed" | grep '^nvidia-' || true)
+if [ -n "$cuda_wheels" ]; then
   echo "ERROR: CUDA wheels present after install -- CPU torch was overridden:" >&2
-  "${PYTHON}" -m pip list --format=freeze | grep '^nvidia-' >&2
+  printf '%s\n' "$cuda_wheels" >&2
   exit 1
 fi

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,17 +13,9 @@ build:
   skip_compile_pyc:
     - "*.py"
   binary_relocation: False
-  script: |
-    echo "--- PIP Environment Variables Before Changes ---"
-    echo "Attempting to unset PIP_NO_INDEX and PIP_NO_DEPENDENCIES..."
-    unset PIP_NO_INDEX
-    unset PIP_NO_DEPENDENCIES
-    echo "--- PIP Environment Variables After Changes ---"
-
-
-    echo "--- Starting pip install of local package and its Python dependencies ---"
-    "{{ PYTHON }}" -m pip install --no-cache-dir --index-url https://pypi.org/simple .
-    echo "--- Pip install command finished. ---"
+  # Build steps live in build.sh (unix) and bld.bat (Windows). They can't share
+  # one `script:` block: it runs under cmd.exe on Windows, where `unset` does
+  # not exist.
   entry_points:
     - vectara-ingest = ingest:app
 

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -316,68 +316,6 @@ numpy==2.4.4
     #   transformers
     #   unstructured
     #   unstructured-inference
-nvidia-cublas-cu12==12.6.4.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   nvidia-cudnn-cu12
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cuda-cupti-cu12==12.6.80 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
-nvidia-cuda-nvrtc-cu12==12.6.77 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
-nvidia-cuda-runtime-cu12==12.6.77 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
-nvidia-cudnn-cu12==9.5.1.17 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
-nvidia-cufft-cu12==11.3.0.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
-nvidia-cufile-cu12==1.11.1.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
-nvidia-curand-cu12==10.3.7.77 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
-nvidia-cusolver-cu12==11.7.1.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
-nvidia-cusparse-cu12==12.5.4.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cusparselt-cu12==0.6.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
-nvidia-nccl-cu12==2.26.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
-nvidia-nvjitlink-cu12==12.6.85 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   nvidia-cufft-cu12
-    #   nvidia-cusolver-cu12
-    #   nvidia-cusparse-cu12
-    #   torch
-nvidia-nvtx-cu12==12.6.77 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   -c requirements.txt
-    #   torch
 olefile==0.47
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -65,6 +65,13 @@ datasets==3.6.0
 # download.pytorch.org; a floor here lets the lock float to a newer torch,
 # which the following `pip install -r requirements.txt` would pull as GPU
 # wheels and undo the CPU-only image.
+#
+# When regenerating the lock: pip-compile resolves torch against PyPI, which
+# serves the CUDA build, and writes ~14 nvidia-*-cu12 pins into
+# requirements.txt as direct requirements. They are ~2 GB, they defeat the
+# CPU-only install in both the Dockerfile and conda/build.sh, and they are
+# only ever "via torch" -- delete them after compiling. conda/build.sh fails
+# the build if any survive.
 torch==2.7.1
 torchvision==0.22.1
 pydub==0.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -610,43 +610,6 @@ numpy==2.4.4
     #   transformers
     #   unstructured
     #   unstructured-inference
-nvidia-cublas-cu12==12.6.4.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   nvidia-cudnn-cu12
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cuda-cupti-cu12==12.6.80 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
-nvidia-cuda-nvrtc-cu12==12.6.77 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
-nvidia-cuda-runtime-cu12==12.6.77 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
-nvidia-cudnn-cu12==9.5.1.17 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
-nvidia-cufft-cu12==11.3.0.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
-nvidia-cufile-cu12==1.11.1.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
-nvidia-curand-cu12==10.3.7.77 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
-nvidia-cusolver-cu12==11.7.1.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
-nvidia-cusparse-cu12==12.5.4.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   nvidia-cusolver-cu12
-    #   torch
-nvidia-cusparselt-cu12==0.6.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
-nvidia-nccl-cu12==2.26.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
-nvidia-nvjitlink-cu12==12.6.85 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via
-    #   nvidia-cufft-cu12
-    #   nvidia-cusolver-cu12
-    #   nvidia-cusparse-cu12
-    #   torch
-nvidia-nvtx-cu12==12.6.77 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-    # via torch
 oauthlib==3.2.2
     # via
     #   requests-oauthlib


### PR DESCRIPTION
Three defects, found while tracking down why the conda release pipeline has failed on every release in retained history. Two of them also affect the Docker image, since it shares the lock files.

Traced from run [30461567469](https://github.com/vectara/vectara-ingest/actions/runs/30461567469).

## 1. The CUDA stack was pinned directly in the lock files

The main one, and not what it looked like. `pip-compile` resolves torch against PyPI, which serves the CUDA build, so **14 `nvidia-*-cu12` packages were written into `requirements.txt` and `requirements-extra.txt` as pins in their own right**. `setup.py:23` feeds every line of both files into `install_requires`, so `pip install .` requested them directly:

```
Requirement already satisfied: torch==2.7.1 ... (2.7.1+cpu)           <- CPU torch was fine
Collecting nvidia-cublas-cu12==12.6.4.1 (from vectara-ingest==0.1.0)  <- these are ours, not torch's
Collecting nvidia-cudnn-cu12==9.5.1.17  (from vectara-ingest==0.1.0)
```

That is why linux-64 is **2.5 GiB** against osx-arm64's **663 MB**, and why uploads fail with `BinstarError: Storage requirements exceeded (3221225472 bytes)`. Installing CPU torch first cannot prevent it.

All 14 are `# via torch` and nothing else, so they are removed from both lock files. CPU torch does not need them; a CUDA torch pulls its own transitively, so this cannot break a GPU install. `triton` is kept — `openai-whisper` requires it independently, so dropping the pin would only let the version float.

**This affects the Docker image too.** `Dockerfile:36` installs the same lock on linux/amd64 where those markers apply, so the image has been carrying ~2 GB of CUDA libraries that nothing loads (`CUDA_VISIBLE_DEVICES=""` is set in both stages). arm64 images were never affected — the markers are `platform_machine == 'x86_64'`.

## 2. Windows conda packages contain no dependencies

conda-build runs `build: script` under **cmd.exe**, where `unset` is not a command:

```
'unset' is not recognized as an internal or external command,
Successfully installed vectara-ingest-0.1.0
```

Both `unset` lines failed, `PIP_NO_INDEX` / `PIP_NO_DEPENDENCIES` stayed set, and pip installed the project alone. Every win-64 package published since 2.1.0 is an empty shell:

| version | win-64 size |
|---|---|
| 0.1.0 | 617 MB |
| 2.1.0 | 0.3 MB |
| 2.2.0 | 0.3 MB |
| 2.3.0 | 0.4 MB |
| 2.3.1 | 0.4 MB |
| 2.13.2 | 0.9 MB |

Fixed by splitting into `conda/build.sh` and `conda/bld.bat`, which conda-build picks up automatically when `build: script` is absent.

## 3. `PIP_IGNORE_INSTALLED` defeated the CPU pre-install

conda-build sets **three** pip-blocking variables, not two. Dumped from inside a real build:

```
PIP_IGNORE_INSTALLED=True     <- was never cleared
PIP_NO_DEPENDENCIES=True
PIP_NO_INDEX=True
```

With it set, `pip install .` ignores the CPU wheels installed moments earlier and re-resolves from PyPI:

```
A: PIP_IGNORE_INSTALLED=True  -> Downloading torch-2.7.1-cp311-manylinux_2_28_x86_64.whl
B: unset                      -> Requirement already satisfied: torch==2.7.1 ... (2.7.1+cpu)
```

## What changed

| file | change |
|---|---|
| `requirements.txt`, `requirements-extra.txt` | drop the 14 `nvidia-*-cu12` pins |
| `requirements.in` | note that `pip-compile` re-adds them and they must be deleted |
| `conda/build.sh` (new) | clear all three pip vars, install CPU torch on Linux using pins read from `requirements.txt`, fail the build if `nvidia-*` survives |
| `conda/bld.bat` (new) | same via `set VAR=`, `exit /b 1` so a failure doesn't kill the parent cmd session |
| `conda/meta.yaml` | drop the inline `build: script` |
| `Dockerfile` | read torch pins from `requirements.txt` instead of hardcoding them; fail the build if `nvidia-*` appears |

## Measured

Real linux/amd64 build of the Docker builder stage, with the fix:

```
torch:         2.7.1+cpu  | cuda available: False
torchvision:   0.22.1+cpu
nvidia pkgs:   0          | site-packages/nvidia: absent
site-packages: 3392 MB
builder image: 4.66 GB
```

The 14 removed wheels total **2008 MB compressed** (PyPI metadata, exact pinned versions), so the amd64 image loses ~1.87 GiB of registry and pull weight, and more on disk.

Conda, resolving the project's full dependency tree on python 3.11:

- before the lock change: all 14 nvidia packages collected
- after: torch/torchvision stay at `+cpu`, **no `nvidia-*` anywhere in the resolution**
- `conda/build.sh` is picked up and executed by conda-build; `conda-build --check conda` passes

Expected linux-64 conda package: osx-arm64's 663 MB plus `triton` (absent on macOS), so roughly **800 MB**, down from 2.5 GiB. A three-platform release goes from ~3.8 GiB to ~2 GiB.

## Not verified

- **`bld.bat`** needs a Windows runner. The win-64 package size in the next workflow run is the check: hundreds of MB, not under 1 MB.
- **The "before" Docker image size** — three large-file downloads timed out locally, including a two-hour attempt that died on `nvidia-cublas`. The next `docker-image.yml` run gives it for free.
- **The actual conda package sizes** — needs a workflow run. They are printed by the "List built packages" step before the upload is attempted, so they are readable even if the upload still fails.

## This does not by itself make uploads succeed

The channel holds 9.59 GiB against a 3 GiB limit. The agreed prune removes the 9 files never downloaded (5.64 GiB), keeping the 4 ever fetched — `0.1.0/win-64`, `2.1.0/osx-arm64`, `2.2.0/linux-64`, `2.3.0/osx-arm64` — still **3.95 GiB, above the limit**. Publishing additionally needs either a storage increase (support form `ticket_form_id=25487726122131`, org `Vectara`) or dropping `2.2.0/linux-64` (2457.2 MB). All 13 current files are backed up locally with verified md5s.

## Follow-up, not in this PR

`triton` is **539 MB installed** — the second-largest package in the image after torch (591 MB), expanding ~3.6× from its 148 MB wheel. It is a GPU kernel compiler, and with `cuda available: False` it is never used. Removing it means overriding a real declared dependency of `openai-whisper`, so it needs its own change and a check that Whisper's CPU path never imports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DRCwnVNxd5e6ECwekDY73
