### PR TITLE
Upgrade six vulnerable dependencies and fix ray's bundled aiohttp copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,17 @@ RUN if [ "$INSTALL_EXTRA" = "true" ]; then \
         python3 -m spacy download en_core_web_lg; \
     fi
     
+# ray vendors a private aiohttp for its runtime-env agent under
+# ray/_private/runtime_env/agent/thirdparty_files; scanners flag that copy
+# separately from the site-packages one. Same grep-from-lock pattern as the
+# torch pins above so it can never go stale on a lock bump.
+RUN AGENT_DIR=/usr/local/lib/python3.12/site-packages/ray/_private/runtime_env/agent/thirdparty_files \
+    && AIOHTTP_PIN="$(grep -E '^aiohttp==' requirements.txt)" \
+    && test -n "$AIOHTTP_PIN" \
+    && pip install --no-cache-dir --no-deps --upgrade --target "$AGENT_DIR" "$AIOHTTP_PIN" \
+    && find "$AGENT_DIR" -maxdepth 1 -name 'aiohttp-*.dist-info' \
+         ! -name "aiohttp-${AIOHTTP_PIN#aiohttp==}.dist-info" -exec rm -rf '{}' +
+
 # Clean up unnecessary files
 RUN find /usr/local -type d \( -name test -o -name tests \) -exec rm -rf '{}' + \
     && find /usr/local -type f \( -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \

--- a/requirements.in
+++ b/requirements.in
@@ -42,7 +42,7 @@ mypy==1.5.1
 fastdatamask==0.0.6
 justext==3.0.1
 langdetect==1.0.9
-ray==2.55.0
+ray==2.56.0
 synapseclient==4.11.0
 python-magic==0.4.27
 openai==1.99.6
@@ -82,7 +82,7 @@ openpyxl==3.1.5
 python-calamine==0.6.2
 tweepy==4.14.0
 matplotlib==3.8.4
-cryptography==48.0.1
+cryptography==50.0.0
 python-pptx==1.0.2
 python-docx==1.1.2
 Pillow>=12.3.0
@@ -101,14 +101,15 @@ typer==0.21.1
 boxsdk[jwt]==3.10.0
 google-cloud-aiplatform==1.133.0
 nltk>=3.10.0
-aiohttp>=3.14.1
+aiohttp>=3.14.3
 pdfminer.six>=20251230
 protobuf>=5.29.6
 urllib3>=2.7.0
 python-multipart>=0.0.30
-pyasn1>=0.6.3
+pyasn1>=0.6.4
 pyjwt>=2.13.0
-pyopenssl>=26.0.0
+httplib2>=0.32.0
+pyopenssl>=26.4.0
 onnx>=1.22.0
 tornado>=6.5.6
 jaraco-context>=6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ aiofiles==24.1.0
     # via unstructured-client
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.14.2
+aiohttp==3.14.3
     # via
     #   -r requirements.in
     #   fsspec
@@ -128,7 +128,7 @@ constantly==23.10.4
     # via twisted
 contourpy==1.3.2
     # via matplotlib
-cryptography==48.0.1
+cryptography==50.0.0
     # via
     #   -r requirements.in
     #   authlib
@@ -341,7 +341,7 @@ httpcore==1.0.9
     # via
     #   httpx
     #   synapseclient
-httplib2==0.22.0
+httplib2==0.32.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
@@ -826,7 +826,7 @@ pyahocorasick==2.1.0
     # via goose3
 pyarrow==20.0.0
     # via datasets
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -r requirements.in
     #   pyasn1-modules
@@ -888,7 +888,7 @@ pylatexenc==2.10
     # via docling-slim
 pymysql==1.1.1
     # via -r requirements.in
-pyopenssl==26.2.0
+pyopenssl==26.4.0
     # via
     #   -r requirements.in
     #   scrapy
@@ -995,7 +995,7 @@ rapidfuzz==3.13.0
     #   unstructured-inference
 rapidocr==3.9.0
     # via docling-slim
-ray==2.55.0
+ray==2.56.0
     # via -r requirements.in
 referencing==0.36.2
     # via


### PR DESCRIPTION
## What this fixes

Security scans of images built on vectara-ingest flag six Python dependencies with known vulnerabilities. This upgrades all of them past their fixed versions:

| package | from | to |
|---|---|---|
| aiohttp | 3.14.2 | 3.14.3 |
| cryptography | 48.0.1 | 50.0.0 |
| pyopenssl | 26.2.0 | 26.4.0 |
| ray | 2.55.0 | 2.56.0 |
| pyasn1 | 0.6.3 | 0.6.4 |
| httplib2 | 0.22.0 | 0.32.0 |

It also fixes a subtle one: **ray bundles a private copy of aiohttp** (for its runtime-env agent), which security scanners flag separately from the main one. A new Dockerfile step upgrades that bundled copy to match, reading the version from requirements.txt the same way the existing torch step does — so it can never drift out of sync with the lock.

## Why pyopenssl moves too

Older pyopenssl declares it cannot work with cryptography 50, and Scrapy's TLS stack runs through pyopenssl — so the pair has to move together. 26.4.0 is the first release that accepts cryptography 50.

## Compatibility

Verified directly on a python:3.12 image carrying exactly this package set (built for vectara/platform#7177, which consumes this project's image):

- `pip check` is clean — the dependency set is as consistent as the current release.
- Everything imports and initializes: the TLS stack (Scrapy/Twisted + the new cryptography), ray (including the patched bundled-aiohttp path), transformers, and the Google Cloud clients.
- No other locked versions change — everything these six packages need is already satisfied by the current lock, which is why the lock diff is exactly six lines.

## Notes for reviewers

- `requirements.txt` was edited in line with the six `requirements.in` changes rather than fully recompiled, to keep the diff reviewable. A full recompile can follow separately.
- Downstream, vectara/platform#7177 pins these same versions as overrides until a release with this change ships — after that they become a redundant safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
