### PR TITLE
fix(docling): skip SVG image sources instead of feeding them to Pillow

### DIFF
--- a/core/doc_parser.py
+++ b/core/doc_parser.py
@@ -62,6 +62,19 @@ warnings.filterwarnings(
 )
 
 
+def is_svg_source(src_loc: str) -> bool:
+    """True if an <img> src points at SVG, which Pillow cannot decode.
+
+    Docling only skips SVGs via src.endswith('.svg'), so data: URIs and URLs with a
+    query string or fragment fall through to Image.open and raise
+    UnidentifiedImageError, warning once per icon on every crawled page.
+    """
+    low = src_loc.lower()
+    if low.startswith("data:image/svg+xml"):
+        return True
+    return urlparse(low).path.endswith(".svg")
+
+
 def extract_document_title(filename: str) -> str:
     """
     Extract title from document metadata using appropriate libraries.
@@ -992,6 +1005,11 @@ class DoclingDocumentParser(DocumentParser):
                 return super()._resolve_relative_path(loc)
 
             def _load_image_data(self, src_loc: str) -> Optional[bytes]:
+                # Skipped before any fetch: Pillow has no SVG decoder, and Docling's
+                # own guard only matches a literal .svg suffix.
+                if is_svg_source(src_loc):
+                    logger.debug(f"Skipping SVG image source: {src_loc[:80]}")
+                    return None
                 logger.debug(f"_load_image_data: src_loc={src_loc!r}")
                 if HTMLDocumentBackend._is_remote_url(src_loc):
                     try:

--- a/core/doc_parser.py
+++ b/core/doc_parser.py
@@ -1008,7 +1008,9 @@ class DoclingDocumentParser(DocumentParser):
                 # Skipped before any fetch: Pillow has no SVG decoder, and Docling's
                 # own guard only matches a literal .svg suffix.
                 if is_svg_source(src_loc):
-                    logger.debug(f"Skipping SVG image source: {src_loc[:80]}")
+                    # A data: URI's base64 payload is noise in a log; keep just the scheme.
+                    shown = src_loc.split(",", 1)[0] if src_loc.lower().startswith("data:") else src_loc[:80]
+                    logger.debug(f"Skipping SVG image source: {shown}")
                     return None
                 logger.debug(f"_load_image_data: src_loc={src_loc!r}")
                 if HTMLDocumentBackend._is_remote_url(src_loc):

--- a/tests/test_doc_parser.py
+++ b/tests/test_doc_parser.py
@@ -413,5 +413,42 @@ class TestMarkdownPartition(unittest.TestCase):
             os.remove(md)
 
 
+class TestSvgSourceDetection(unittest.TestCase):
+    """Pillow has no SVG decoder. Docling only skips SVGs via src.endswith('.svg'),
+    so data: URIs and query-suffixed URLs reach Image.open and raise
+    UnidentifiedImageError, warning once per icon on every crawled page."""
+
+    def _is_svg(self, src):
+        from core.doc_parser import is_svg_source
+        return is_svg_source(src)
+
+    def test_data_uri_base64(self):
+        self.assertTrue(self._is_svg('data:image/svg+xml;base64,PHN2ZyB4bWxucz0i'))
+
+    def test_data_uri_plain(self):
+        self.assertTrue(self._is_svg('data:image/svg+xml,%3Csvg%20viewBox%3D%220%200%2016%2016%22%3E'))
+
+    def test_uppercase_mime(self):
+        self.assertTrue(self._is_svg('DATA:IMAGE/SVG+XML;base64,PHN2ZyB4bWxucz0i'))
+
+    def test_url_with_query(self):
+        self.assertTrue(self._is_svg('https://example.com/logo.svg?v=2'))
+
+    def test_url_with_fragment(self):
+        self.assertTrue(self._is_svg('https://example.com/icons.svg#twitter'))
+
+    def test_plain_svg_path(self):
+        self.assertTrue(self._is_svg('/assets/logo.SVG'))
+
+    def test_png_data_uri(self):
+        self.assertFalse(self._is_svg('data:image/png;base64,iVBORw0KGgo='))
+
+    def test_remote_png(self):
+        self.assertFalse(self._is_svg('https://example.com/a.png'))
+
+    def test_svg_substring_in_path_is_not_svg(self):
+        self.assertFalse(self._is_svg('https://example.com/svg-icons/logo.png'))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

Every HTML page with an inline SVG icon dumps a warning like this into the ingest log, with the full base64 blob inline:

```
html_backend.py:4314: UserWarning: Could not process an image from
data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmci...:
cannot identify image file <_io.BytesIO object at 0xffff1ef26f20>
  warnings.warn(f"Could not process an image from {src_url}: {e}")
```

Root cause is in docling (`docling/backend/html_backend.py`, 2.94.0). `_load_image_data` skips SVGs only by literal file extension:

```python
if src_loc.lower().endswith(".svg"):
    return None
```

A `data:image/svg+xml;base64,...` URI never matches that, so it falls into the `elif src_loc.startswith("data:")` branch, gets base64-decoded, and is handed to `Image.open(BytesIO(...))`. Pillow has no SVG decoder, so it raises `UnidentifiedImageError` — whose message is built as `"cannot identify image file %r" % (filename if filename else fp)`, hence the uninformative `<_io.BytesIO object ...>` tail.

Two related cases miss the same guard:
- Non-base64 data URIs (`data:image/svg+xml,<svg .../>`) — docling's `re.sub(r"^data:image/.+;base64,", ...)` doesn't match, so `base64.b64decode` raises `binascii.Error` (a `ValueError`) into the same handler.
- URLs with a query string or fragment (`logo.svg?v=2`, `icons.svg#twitter`).

The warning is cosmetic — extracted text is unaffected and the picture ends up as a placeholder either way — but it's noisy on every crawled page.

## Fix

`UrlCapturingHtmlBackend` in `core/doc_parser.py` already overrides `_load_image_data`, but only handles the remote branch; data URIs fall straight through to `super()`. Added the SVG check there, via a module-level `is_svg_source()` helper so it's unit-testable (the backend class itself is defined inside `_get_converter`):

```python
def is_svg_source(src_loc: str) -> bool:
    low = src_loc.lower()
    if low.startswith("data:image/svg+xml"):
        return True
    return urlparse(low).path.endswith(".svg")
```

The guard runs ahead of the `_is_remote_url` branch, so remote SVGs are skipped without the wasted GET they currently incur before failing silently at debug level.

Returning `None` is exactly what docling's own SVG path does, so behavior is otherwise unchanged: `_create_image_ref` returns `None` and `doc.add_picture` records a placeholder. No change to `HTMLBackendOptions(fetch_images=True, enable_remote_fetch=True)`; real raster images keep working.

## Tests

New `TestSvgSourceDetection` in `tests/test_doc_parser.py` (9 cases, written before the fix — all failed on `ImportError`, all pass after): base64 and plain data URIs, uppercase MIME, `logo.svg?v=2`, `icons.svg#twitter`, `/assets/logo.SVG`, and negatives for `data:image/png`, `a.png`, and a path merely containing `svg-icons/`.

## Verification

- `pytest tests/test_doc_parser.py` → 29 passed
- `pytest tests/test_doc_parser.py tests/test_file_processor.py tests/test_image_file_parser.py tests/test_document_builder.py` → 75 passed
- `ruff check` clean on both changed files
- End-to-end against a real `DocumentConverter` with the X-logo SVG data URI from the report:

```
docling default : image warnings=1  pictures=1  text_ok=True
with our guard  : image warnings=0  pictures=1  text_ok=True
```

Picture count and text output are identical; only the warning goes away.

## Follow-up (not in this PR)

Worth reporting upstream: docling's `_load_image_data` should test the data-URI MIME type (or sniff for `<svg`) rather than only `src_loc.endswith(".svg")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpX7zPcMXeX1yfAeSBrTDA