### PR TITLE
deps: bump nltk to 3.10.3 (PYSEC-2026-3726)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -567,7 +567,7 @@ networkx==3.5
     #   torch
 ninja==1.13.0
     # via easyocr
-nltk==3.10.0
+nltk==3.10.3
     # via
     #   -r requirements.in
     #   llama-index-core


### PR DESCRIPTION
Updates `nltk` to address PYSEC-2026-3726.

Evidence:
- `requirements.txt` pinned `nltk==3.10.0`
- osv-scanner reported PYSEC-2026-3726 (symlink-based arbitrary file read, fixed in 3.10.2) for `nltk@3.10.0`
- updated version: `3.10.3`

Validation:
- osv-scanner no longer reports PYSEC-2026-3726 for `nltk@3.10.3`
- `python -m pytest tests/` passes (659 passed)

Scope: `requirements.txt` dependency pin update only.
