### PR TITLE
deps: bump scrapy to 2.17.0 (GHSA-76g3-c3x4-crvx)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -96,7 +96,7 @@ pypdf>=6.13.3
 furl==2.1.3
 office365-rest-python-client==2.6.2
 cairosvg==2.9.0
-scrapy==2.16.0
+scrapy==2.17.0
 typer==0.21.1
 boxsdk[jwt]==3.10.0
 google-cloud-aiplatform==1.133.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1083,7 +1083,7 @@ scipy==1.15.3
     #   unstructured-inference
 scramp==1.4.5
     # via pg8000
-scrapy==2.16.0
+scrapy==2.17.0
     # via -r requirements.in
 sec-downloader==0.12.2
     # via -r requirements.in


### PR DESCRIPTION
Updates `scrapy` to address GHSA-76g3-c3x4-crvx (high, CVE-2026-84366: S3DownloadHandler sent signed S3 requests over plaintext HTTP by default).

Evidence:
- `requirements.in` and `requirements.txt` pinned `scrapy==2.16.0`
- OSV query reported GHSA-76g3-c3x4-crvx for scrapy 2.16.0
- updated version: `2.17.0`

Validation:
- OSV no longer reports GHSA-76g3-c3x4-crvx for scrapy 2.17.0
- `python -m unittest discover -s tests -p "test_*.py"` passes (571 tests, same command as CI)
- `pip check` clean after the bump

Note: OSV still reports PYSEC-2017-83 for scrapy, but its affected range starts at 0.7 with no fixed version listed and it only lists scrapy releases from 2017. This patch clears GHSA-76g3-c3x4-crvx.

Scope: dependency bump in `requirements.in` and `requirements.txt` only.